### PR TITLE
Update INavigationService.cs

### DIFF
--- a/src/Caliburn.Micro.Platform/win8/INavigationService.cs
+++ b/src/Caliburn.Micro.Platform/win8/INavigationService.cs
@@ -130,6 +130,11 @@
 
             this.frame.Navigating += OnNavigating;
             this.frame.Navigated += OnNavigated;
+            
+#if WP81
+            this.frame.Loaded += (sender, args) => { HardwareButtons.BackPressed += HardwareButtons_BackPressed; };
+            this.frame.Unloaded += (sender, args) => { HardwareButtons.BackPressed -= HardwareButtons_BackPressed; };
+#endif
         }
 
         /// <summary>
@@ -424,6 +429,17 @@
 
             return true;
         }
+
+#if WP81
+        private void HardwareButtons_BackPressed(object sender, Windows.Phone.UI.Input.BackPressedEventArgs e)
+        {
+            if (CanGoBack)
+            {
+                e.Handled = true;
+                GoBack();
+            }
+        }
+#endif
 
         private static ApplicationDataContainer GetSettingsContainer() {
             return ApplicationData.Current.LocalSettings.CreateContainer("Caliburn.Micro",


### PR DESCRIPTION
The current version of Caliburn.Micro for Windows Phone 8.1 does not allow back navigation using the back physical key. It will close the application straight. This patch fixes this issue using code as provided in the Universal apps template.
