### PR TITLE
Allow transition animation overriding in NavigationService.

### DIFF
--- a/src/Caliburn.Micro.Extensions.WIN8/NavigationExtensions.cs
+++ b/src/Caliburn.Micro.Extensions.WIN8/NavigationExtensions.cs
@@ -10,11 +10,24 @@
         /// </summary>
         /// <param name="navigationService">The navigation service.</param>
         /// <param name="parameter">The object parameter to pass to the target.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
         /// <typeparam name="T">The <see cref="System.Type" /> to navigate to.</typeparam>
         /// <returns>Whether or not navigation succeeded.</returns>
+#if WinRT81 || WP81
+        public static bool Navigate<T>(this INavigationService navigationService, object parameter = null,
+            Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo infoOverride = null) {
+
+            if (infoOverride == null) {
+                return navigationService.Navigate(typeof(T), parameter);
+            }
+
+            return navigationService.Navigate(typeof(T), parameter, infoOverride);
+        }
+#else
         public static bool Navigate<T>(this INavigationService navigationService, object parameter = null) {
             return navigationService.Navigate(typeof (T), parameter);
         }
+#endif
 
         /// <summary>
         /// Navigate to the specified model type.
@@ -22,7 +35,24 @@
         /// <param name="navigationService">The navigation service.</param>
         /// <param name="viewModelType">The model type to navigate to.</param>
         /// <param name="parameter">The object parameter to pass to the target.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
         /// <returns>Whether or not navigation succeeded.</returns>
+#if WinRT81 || WP81
+        public static bool NavigateToViewModel(this INavigationService navigationService, Type viewModelType,
+            object parameter = null, Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo infoOverride = null) {
+            var viewType = ViewLocator.LocateTypeForModelType(viewModelType, null, null);
+            if (viewType == null) {
+                throw new InvalidOperationException(
+                    string.Format("No view was found for {0}. See the log for searched views.", viewModelType.FullName));
+            }
+
+            if (infoOverride == null) {
+                return navigationService.Navigate(viewType, parameter);
+            }
+
+            return navigationService.Navigate(viewType, parameter, infoOverride);
+        }
+#else
         public static bool NavigateToViewModel(this INavigationService navigationService, Type viewModelType,
             object parameter = null) {
             var viewType = ViewLocator.LocateTypeForModelType(viewModelType, null, null);
@@ -33,17 +63,28 @@
 
             return navigationService.Navigate(viewType, parameter);
         }
+#endif
+
 
         /// <summary>
         /// Navigate to the specified model type.
         /// </summary>
         /// <param name="navigationService">The navigation service.</param>
         /// <param name="parameter">The object parameter to pass to the target.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
         /// <typeparam name="T">The model type to navigate to.</typeparam>
         /// <returns>Whether or not navigation succeeded.</returns>
+#if WinRT81 || WP81
+        public static bool NavigateToViewModel<T>(this INavigationService navigationService, object parameter = null,
+            Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo infoOverride = null) {
+
+            return navigationService.NavigateToViewModel(typeof (T), parameter, infoOverride);
+        }
+#else
         public static bool NavigateToViewModel<T>(this INavigationService navigationService, object parameter = null) {
             return navigationService.NavigateToViewModel(typeof (T), parameter);
         }
+#endif
 
         /// <summary>
         /// Creates a Uri builder based on a view model type.

--- a/src/Caliburn.Micro.Extensions.WIN8/UriBuilder.cs
+++ b/src/Caliburn.Micro.Extensions.WIN8/UriBuilder.cs
@@ -4,6 +4,10 @@
     using System.Linq;
     using System.Linq.Expressions;
 
+#if WinRT81 || WP81
+    using Windows.UI.Xaml.Media.Animation;
+#endif
+
     /// <summary>
     /// Builds a Uri in a strongly typed fashion, based on a ViewModel.
     /// </summary>
@@ -11,6 +15,10 @@
     public class UriBuilder<TViewModel> {
         readonly Dictionary<string, string> queryString = new Dictionary<string, string>();
         INavigationService navigationService;
+
+#if WinRT81 || WP81
+        NavigationTransitionInfo infoOverride;
+#endif
 
         /// <summary>
         /// Adds a query string parameter to the Uri.
@@ -26,6 +34,18 @@
 
             return this;
         }
+
+#if WinRT81 || WP81
+        /// <summary>
+        /// Overrides the animated transition defined in the page.
+        /// </summary>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns>Itself</returns>
+        public UriBuilder<TViewModel> WithTransition(NavigationTransitionInfo infoOverride) {
+            this.infoOverride = infoOverride;
+            return this;
+        }
+#endif
 
         /// <summary>
         /// Attaches a navigation servies to this builder.
@@ -46,7 +66,9 @@
             if (navigationService == null) {
                 throw new InvalidOperationException("Cannot navigate without attaching an INavigationService. Call AttachTo first.");
             }
-#if WinRT
+#if WinRT81 || WP81
+            navigationService.NavigateToViewModel<TViewModel>(uri.AbsoluteUri, infoOverride);
+#elif WinRT
             navigationService.NavigateToViewModel<TViewModel>(uri.AbsoluteUri);
 #else
             navigationService.Navigate(uri);

--- a/src/Caliburn.Micro.Platform/win8/INavigationService.cs
+++ b/src/Caliburn.Micro.Platform/win8/INavigationService.cs
@@ -12,6 +12,10 @@ namespace Caliburn.Micro {
     using Windows.Phone.UI.Input;
 #endif
 
+#if WinRT
+    using Windows.UI.Xaml.Media.Animation;
+#endif
+
     /// <summary>
     ///   Implemented by services that provide (<see cref="Uri" /> based) navigation.
     /// </summary>
@@ -70,6 +74,17 @@ namespace Caliburn.Micro {
         /// <param name="parameter">The object parameter to pass to the target.</param>
         /// <returns> Whether or not navigation succeeded. </returns>
         bool Navigate(Type sourcePageType, object parameter);
+
+#if WinRT81 || WP81
+        /// <summary>
+        ///   Navigates to the specified content.
+        /// </summary>
+        /// <param name="sourcePageType"> The <see cref="System.Type" /> to navigate to. </param>
+        /// <param name="parameter">The object parameter to pass to the target.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns> Whether or not navigation succeeded. </returns>
+        bool Navigate(Type sourcePageType, object parameter, NavigationTransitionInfo infoOverride);
+#endif
 
         /// <summary>
         ///   Navigates forward.
@@ -341,6 +356,20 @@ namespace Caliburn.Micro {
         public bool Navigate(Type sourcePageType, object parameter) {
             return frame.Navigate(sourcePageType, parameter);
         }
+
+#if WinRT81 || WP81
+        /// <summary>
+        ///   Navigates to the specified content.
+        /// </summary>
+        /// <param name="sourcePageType"> The <see cref="System.Type" /> to navigate to. </param>
+        /// <param name="parameter">The object parameter to pass to the target.</param>
+        /// <param name="infoOverride">Info about the animated transition.</param>
+        /// <returns> Whether or not navigation succeeded. </returns>
+        public bool Navigate(Type sourcePageType, object parameter, NavigationTransitionInfo infoOverride)
+        {
+            return frame.Navigate(sourcePageType, parameter, infoOverride);
+        }
+#endif
 
         /// <summary>
         ///   Navigates forward.


### PR DESCRIPTION
There are cases when there's a need to override the transition defined in the page. This pull requests adds the option to do so using the UriBuilder.WithTransition.