### PR TITLE
BindingScope.FindNamedDescendants crashed on DependencyObjects

### DIFF
--- a/src/Caliburn.Micro.Platform/BindingScope.cs
+++ b/src/Caliburn.Micro.Platform/BindingScope.cs
@@ -122,6 +122,13 @@
                     continue;
                 }
 
+                if (current.GetType() == typeof(DependencyObject)) {
+                    // Windows 8.1 ListViews can have direct DependencyObjects as children
+                    // Calling GetChildrenCount on DependencyObject instances throws an error.
+                    // Ignore DependencyObject items, they have no usable children
+                    continue;
+                }
+
 #if NET
                 var childCount = (current is UIElement || current is UIElement3D || current is ContainerVisual
                                         ? VisualTreeHelper.GetChildrenCount(current)


### PR DESCRIPTION
We have a ListView control in a Windows 8.1 app that, for some reason, has DependencyObject instances when getting its children. GetChildrenCount crashed with an "catastrophic error" when calling it these children.

Same as Calling "VisualTreeHelper.GetChildrenCount(new DependencyObject())"

The change skips processing children that are just DependencyObjects
