### PR TITLE
Prevent call to IoC.GetInstance when viewing an element with Action.Target in design mode

### DIFF
--- a/src/Caliburn.Micro.Platform/Action.cs
+++ b/src/Caliburn.Micro.Platform/Action.cs
@@ -130,7 +130,7 @@
         }
 
         static void SetTargetCore(DependencyPropertyChangedEventArgs e, DependencyObject d, bool setContext) {
-            if (e.NewValue == e.OldValue) {
+            if (e.NewValue == e.OldValue || Execute.InDesignMode) {
                 return;
             }
 


### PR DESCRIPTION
When using the attached property Action.Target, all is well at runtime, however at design time both the xaml validation and designer often complain about dependencies and proper initialisation of the IoC class.

I'm not sure if this was a specific intention to let the IoC class try to resolve something at design time. However I think adding a check (like below) would be the better solution.

Further to this, it looks like it can never resolve a named service anyway by default:

```
protected virtual object GetInstance(Type service, string key) {
#if NET
    if (service == typeof(IWindowManager))
        service = typeof(WindowManager);
#endif

    return Activator.CreateInstance(service);
}
```
