### PR TITLE
Added simple gesture trigger example

### DIFF
--- a/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/KeyBindingBootstrapper.cs
+++ b/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/KeyBindingBootstrapper.cs
@@ -27,7 +27,12 @@
                     var key = (Key)Enum.Parse(typeof(Key), splits[1], true);
                     return new KeyTrigger { Key = key };
                 }
-
+                else if (splits[0] == "Gesture")
+                {
+                   var mkg = (MultiKeyGesture)(new MultiKeyGestureConverter()).ConvertFrom(splits[1]);
+                   return new KeyTrigger { Modifiers = mkg.KeySequences[0].Modifiers, Key = mkg.KeySequences[0].Keys[0] };
+                }
+                
                 return trigger(target, triggerText);
             };
         }

--- a/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/ShellView.xaml
+++ b/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/ShellView.xaml
@@ -12,7 +12,7 @@
     <TextBlock />
     <TextBox HorizontalAlignment="Left"
              Width="278"
-             cal:Message.Attach="[Key Enter] = [EnterPressed]">
+             cal:Message.Attach="[Key Enter] = [EnterPressed]; [Gesture Ctrl+Enter] = [CtrlEnterPressed]">
     </TextBox>
     <TextBlock />
     <TextBlock x:Name="EnterMessage"

--- a/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/ShellViewModel.cs
+++ b/samples/Caliburn.Micro.KeyBinding/Caliburn.Micro.KeyBinding/ShellViewModel.cs
@@ -20,5 +20,10 @@
         public void EnterPressed() {
             EnterMessage = "Enter has been pressed";
         }
+
+        public void CtrlEnterPressed()
+        {
+           EnterMessage = "Ctrl+Enter has been pressed";
+        }
     }
 }


### PR DESCRIPTION
I was looking at the Caliburn.Micro samples for keybinding and noticed that while it had code to parse a gesture with keys and modifiers, there was no example of how to use it. Since I needed this functionality, I added an extra Gesture trigger to use the converter to construct a KeyTrigger that has modifiers.

One drawback is that since the KeyTrigger class only supports one Key, it does not make full use of the MultiKeyGesture functionality.

If there is a better way to make use of the MultiKeyGesture/Binding code provided in this sample, please let me know so I can figure out how to use it that way. I'm no expert on the System.Windows.Input or System.Windows.Interactivity APIs at work here.