### PR TITLE
Fixes references to Xamarin.Forms package

### DIFF
--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
@@ -95,12 +95,10 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.1.3.1.6296\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.3.1.6296\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.1.3.1.6296\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.1.3.1.6296\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
     <Error Condition="!Exists('..\packages\Xamarin.Forms.1.4.2.6355\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.1.4.2.6355\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
   </Target>
   <Import Project="..\packages\Xamarin.Forms.1.4.2.6355\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.2.6355\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -4,6 +4,7 @@
   <repository path="..\Caliburn.Micro.Extensions.WIN8\packages.config" />
   <repository path="..\Caliburn.Micro.Platform.XamarinForms\packages.config" />
   <repository path="..\Caliburn.Micro.Platform\packages.Caliburn.Micro.Platform.WIN8.config" />
+  <repository path="..\Caliburn.Micro.Platform\packages.Caliburn.Micro.Platform.Xamarin.Forms.config" />
   <repository path="..\Caliburn.Micro.Platform\packages.config" />
   <repository path="..\Caliburn.Micro.Tests.NET45\packages.config" />
 </repositories>


### PR DESCRIPTION
Line 103 caused build errors if Xamarin.Forms 1.3.1.6296 was not present.