### PR TITLE
Make sure MainWindow isn't disposed before using it as owner

### DIFF
--- a/src/Caliburn.Micro.Platform/net40/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/net40/WindowManager.cs
@@ -203,7 +203,7 @@
             }
 
             var active = application.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
-            active = active ?? application.MainWindow;
+            active = active ?? (PresentationSource.FromVisual(application.MainWindow) == null ? null : application.MainWindow);
             return active == window ? null : active;
         }
 


### PR DESCRIPTION
This is a fix for an edge case where code that is not under my control closes the Application.Current.MainWindow (without closing the actual application because it's native c++ in which WPF is hosted). This previously raises an exception when that closed window is used as Owner when creating a new Dialog.

Using PresentationSource.FromVisual as per http://stackoverflow.com/a/26355993/481635