### PR TITLE
Prepare the view frame when displaying a root view for a view model

### DIFF
--- a/src/Caliburn.Micro.Platform/win8/CaliburnApplication.cs
+++ b/src/Caliburn.Micro.Platform/win8/CaliburnApplication.cs
@@ -233,6 +233,7 @@
         /// <param name="viewModelType">The view model type.</param>
         protected void DisplayRootViewFor(Type viewModelType) {
             Initialize();
+            PrepareViewFirst();
 
             var viewModel = IoC.GetInstance(viewModelType, null);
             var view = ViewLocator.LocateForModel(viewModel, null, null);


### PR DESCRIPTION
The Win8 `CaliburnApplication` calls `PrepareViewFirst()` in `DisplayRootView()` but not in `DisplayRootViewFor()`. Meaning that the frame never gets created when displaying a view for a view model as the root view.

This just adds a call to `PrepareViewFirst()` in `DisplayRootViewFor()` where it gets called in `DisplayRootView()`.