### PR TITLE
Pivot control & Windows UWP

### DIFF
--- a/src/Caliburn.Micro.Platform/ConventionManager.cs
+++ b/src/Caliburn.Micro.Platform/ConventionManager.cs
@@ -230,7 +230,7 @@
             AddElementConvention<Slider>(Slider.ValueProperty, "Value", "ValueChanged");
             AddElementConvention<RichEditBox>(RichEditBox.DataContextProperty, "DataContext", "TextChanged");
 #endif
-#if WP81
+#if WP81 || WINDOWS_UWP
             AddElementConvention<Pivot>(Pivot.ItemsSourceProperty, "SelectedItem", "SelectionChanged")
                 .ApplyBinding = (viewModelType, path, property, element, convention) =>
                 {


### PR DESCRIPTION
Modified the directive for WP81 to include the WINDOWS_UWP directive, which now has access to the Pivot control in Windows UAP apps.