### PR TITLE
Fixed issue which triggered AmbiguousMatchException

### DIFF
--- a/src/Caliburn.Micro.Platform/ViewLocator.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocator.cs
@@ -438,7 +438,7 @@ namespace Caliburn.Micro
         };
 
         /// <summary>
-        ///   When a view does not contain a code-behind file, we need to automatically call InitializeCompoent.
+        ///   When a view does not contain a code-behind file, we need to automatically call InitializeComponent.
         /// </summary>
         /// <param name = "element">The element to initialize</param>
         public static void InitializeComponent(object element) {
@@ -447,7 +447,7 @@ namespace Caliburn.Micro
                 .GetMethod("InitializeComponent", BindingFlags.Public | BindingFlags.Instance);
 #else
             var method = element.GetType().GetTypeInfo()
-                .GetDeclaredMethod("InitializeComponent");
+                .GetDeclaredMethods("InitializeComponent").FirstOrDefault();
 #endif
 
             if (method == null)


### PR DESCRIPTION
In the ViewLocator for UWP apps, this line of code triggered an AmbiguousMatchException
    var method = element.GetType().GetTypeInfo()
                    .GetDeclaredMethod("InitializeComponent");

In UWP apps, there are two methods called "InitializeComponent" for device specific family views, but one takes a Uri as a parameter, so when you call GetDeclaredMethod it will throw that exception.

I fixed this by calling GetDeclaredMethods() and choosing the first one, which doesn't have the Uri parameter.
