### PR TITLE
NavigationPageAdapter now takes ViewModel type into account when pushing view

### DIFF
--- a/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
@@ -85,7 +85,7 @@
 
             var view = ViewLocator.LocateForModelType(viewModelType, null, null);
 
-            return PushAsync(view, parameter, animated);
+            return PushAsync(view, parameter, animated, viewModelType);
         }
 
         /// <summary>
@@ -135,14 +135,14 @@
             return NavigateToViewAsync(typeof(T), parameter, animated);
         }
 
-        private Task PushAsync(Element view, object parameter, bool animated)
+        private Task PushAsync(Element view, object parameter, bool animated, Type viewModelType = null)
         {
             var page = view as Page;
 
             if (page == null)
                 throw new NotSupportedException(String.Format("{0} does not inherit from {1}.", view.GetType(), typeof(Page)));
 
-            var viewModel = ViewModelLocator.LocateForView(view);
+            var viewModel = viewModelType == null ? ViewModelLocator.LocateForView(view) : IoC.GetInstance(viewModelType, null);
 
             if (viewModel != null) {
                 TryInjectParameters(viewModel, parameter);


### PR DESCRIPTION
PushAsync now takes the ViewModel type as an argument (defaults to
null).  If the viewmodel type is specified, it will use IoC to get an
instance of it, as opposed to relying on
ViewModelLocator.LocateForView(which ultimately just uses IoC, anyways).
No reason to look up the viewmodel type again, when we already know it.