### PR TITLE
[WIP] Adapt ContentViews to ContentPages during navigation

### DIFF
--- a/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
@@ -139,8 +139,8 @@
         {
             var page = view as Page;
 
-            if (page == null)
-                throw new NotSupportedException(String.Format("{0} does not inherit from {1}.", view.GetType(), typeof(Page)));
+            if (page == null && !(view is ContentView))
+                throw new NotSupportedException(String.Format("{0} does not inherit from either {1} or {2}.", view.GetType(), typeof(Page), typeof(ContentView)));
 
             var viewModel = ViewModelLocator.LocateForView(view);
 
@@ -148,6 +148,11 @@
                 TryInjectParameters(viewModel, parameter);
 
                 ViewModelBinder.Bind(viewModel, view, null);
+            }
+
+            if (view is ContentView)
+            {
+                page = new ContentPage { Content = (ContentView)view };
             }
 
             page.Appearing += (s, e) => ActivateView(page);

--- a/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
@@ -19,6 +19,26 @@
             this.navigationPage = navigationPage;
         }
 
+
+        /// <summary>
+        /// Allow Xamarin to navigate to a ViewModel backed by a view which is of type <see cref="T:Xamarin.Forms.ContentView"/> by adapting the result
+        /// to a <see cref="T:Xamarin.Forms.ContentPage"/>.
+        /// </summary>
+        /// <param name="view">The view to be adapted</param>
+        /// <param name="viewModel">The view model which is bound to the view</param>
+        /// <returns>The adapted ContentPage</returns>
+        protected virtual ContentPage CreateContentPage(ContentView view, object viewModel)
+        {
+            var page = new ContentPage { Content = view };
+
+            var hasDiplayName = viewModel as IHaveDisplayName;
+            if (hasDiplayName != null) {
+                page.Title = hasDiplayName.DisplayName;
+            }
+
+            return page;
+        }
+
         private static void DeactivateView(BindableObject view)
         {
             if (view == null)
@@ -150,9 +170,9 @@
                 ViewModelBinder.Bind(viewModel, view, null);
             }
 
-            if (view is ContentView)
-            {
-                page = new ContentPage { Content = (ContentView)view };
+            var contentView = view as ContentView;
+            if (contentView != null) {
+                page = CreateContentPage(contentView, viewModel);
             }
 
             page.Appearing += (s, e) => ActivateView(page);

--- a/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
@@ -1,4 +1,6 @@
-﻿namespace Caliburn.Micro.Xamarin.Forms {
+﻿using System.Reflection;
+
+namespace Caliburn.Micro.Xamarin.Forms {
 
     using System;
     using System.Collections.Generic;
@@ -33,7 +35,12 @@
 
             var hasDiplayName = viewModel as IHaveDisplayName;
             if (hasDiplayName != null) {
-                page.Title = hasDiplayName.DisplayName;
+
+                var path = "DisplayName";
+                var property = typeof(IHaveDisplayName).GetRuntimeProperty(path);
+                ConventionManager.SetBinding(viewModel.GetType(), path, property, page, null, Page.TitleProperty);
+
+                page.BindingContext = viewModel;
             }
 
             return page;


### PR DESCRIPTION
This change allows the `NavigationPageAdapter` to also use a `ContentView` when navigating. I found Xamarin to be a bit too restrictive around it's usage of these for no real reason.

FWIW this allows the same top level view to be either composed as part of a tab/master detail or be navigated to using the navigation service without actually having to change the object type. I wasn't too sure whether this behavior should be baked into the `NavigationPageAdapter` or whether an additional extension point should be added allowing the user to intercept the view and modify it right before it is bound, but happy to make those changes as well if you think it would be worthwhile.