### PR TITLE
#375 support multiple parameters of the same type

### DIFF
--- a/src/Caliburn.Micro.Tests.NET45/SimpleContainerTests.cs
+++ b/src/Caliburn.Micro.Tests.NET45/SimpleContainerTests.cs
@@ -73,6 +73,42 @@
         }
     }
 
+
+    public class SimpleContainer_Resolve_different_parameters_of_same_type {
+        public class SingleTwoIntsConstructor
+        {
+            public int Value { get; private set; }
+
+            public SingleTwoIntsConstructor(int x, int y)
+            {
+                this.Value = x * 10 + y;
+            }
+        }
+
+        [Fact]
+        public void Container_SingleTwoIntsConstructor()
+        {
+            var container = new SimpleContainer();
+            container.Singleton<SingleTwoIntsConstructor>();
+            container.RegisterInstance(typeof(int), "y", 2);
+            container.RegisterInstance(typeof(int), "x", 4);
+            var inst = (SingleTwoIntsConstructor)container.GetInstance(typeof(SingleTwoIntsConstructor), null);
+            Assert.Equal(42, inst.Value);
+        }
+
+        [Fact]
+        public void Container_SingleTwoIntsConstructor_registeredInDifferentOrder()
+        {
+            var container = new SimpleContainer();
+            container.Singleton<SingleTwoIntsConstructor>();
+            container.RegisterInstance(typeof(int), "x", 4);
+            container.RegisterInstance(typeof(int), "y", 2);
+            var inst = (SingleTwoIntsConstructor)container.GetInstance(typeof(SingleTwoIntsConstructor), null);
+            Assert.Equal(42, inst.Value);
+        }
+
+    }
+
     public class SimpleContainer_Registering_Instances {
         [Fact]
         public void Instances_registered_PerRequest_returns_a_different_instance_for_each_call() {

--- a/src/Caliburn.Micro/SimpleContainer.cs
+++ b/src/Caliburn.Micro/SimpleContainer.cs
@@ -217,7 +217,9 @@
             var constructor = SelectEligibleConstructor(implementation);
 
             if (constructor != null)
-                args.AddRange(constructor.GetParameters().Select(info => GetInstance(info.ParameterType, null)));
+                args.AddRange(constructor.GetParameters()
+                    .Select(info => GetInstance(info.ParameterType, info.Name)
+                        ?? GetInstance(info.ParameterType, null)));
 
             return args.ToArray();
         }


### PR DESCRIPTION
if there's more than one parameter registered for a given type, with this commit the instance is preferred, where the registered key matches the argument name in the constructor.
