### PR TITLE
Fixed spelling errors in test names

### DIFF
--- a/src/Caliburn.Micro.Tests.NET45/RegExHelperTests.cs
+++ b/src/Caliburn.Micro.Tests.NET45/RegExHelperTests.cs
@@ -6,7 +6,7 @@ namespace Caliburn.Micro.WPF.Tests {
 
     public class RegExHelperTests {
         [Fact]
-        public void GetCaptureGroupReturnesGroupNameAndRegex() {
+        public void GetCaptureGroupReturnsGroupNameAndRegex() {
             var groupName = "group";
             var regex = ".*";
 

--- a/src/Caliburn.Micro.Tests.NET45/StringSplitterTests.cs
+++ b/src/Caliburn.Micro.Tests.NET45/StringSplitterTests.cs
@@ -29,7 +29,7 @@
         }
 
         [Fact]
-        public void ShouldSplitParametersOnComman()
+        public void ShouldSplitParametersOnComma()
         {
             var message = "message, string, for, testing";
 

--- a/src/Caliburn.Micro.Tests.NET45/ViewLocatorTests.cs
+++ b/src/Caliburn.Micro.Tests.NET45/ViewLocatorTests.cs
@@ -6,7 +6,7 @@ namespace Caliburn.Micro.WPF.Tests
     public class ViewLocatorTests
     {
         [Fact]
-        public void COnfigureTypeMappingsWithDefaultValuesShouldNotThrow()
+        public void ConfigureTypeMappingsWithDefaultValuesShouldNotThrow()
         {
             var typeMappingConfiguration = new TypeMappingConfiguration();
 


### PR DESCRIPTION
Fixed a few spelling errors in the unit tests that had extra characters and some off-casing. No functionality was changed. 