### PR TITLE
Data template selector for Xamarin Froms

### DIFF
--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Parser.cs" />
     <Compile Include="xforms\ActionMessage.cs" />
     <Compile Include="xforms\AttachedCollection.cs" />
+    <Compile Include="xforms\ContextAwareDataTemplateSelector.cs" />
     <Compile Include="xforms\ConventionManager.cs" />
     <Compile Include="xforms\HttpUtility.cs" />
     <Compile Include="xforms\IAttachedObject.cs" />

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.Xamarin.Forms.csproj
@@ -88,15 +88,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.0.1.6505\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.3.175\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.0.1.6505\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.3.175\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.0.1.6505\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.3.175\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -104,12 +104,12 @@
     <None Include="packages.Caliburn.Micro.Platform.Xamarin.Forms.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.3.175\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.175\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.3.3.175\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.3.3.175\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Caliburn.Micro.Platform/packages.Caliburn.Micro.Platform.Xamarin.Forms.config
+++ b/src/Caliburn.Micro.Platform/packages.Caliburn.Micro.Platform.Xamarin.Forms.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.0.1.6505" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="2.3.3.175" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/src/Caliburn.Micro.Platform/xforms/ContextAwareDataTemplateSelector.cs
+++ b/src/Caliburn.Micro.Platform/xforms/ContextAwareDataTemplateSelector.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+
+namespace Caliburn.Micro.Xamarin.Forms
+{
+    /// <summary>
+    /// A DataTemplateSelector that selects the DataTemplate based on the viewModel
+    /// </summary>
+    public class ContextAwareDataTemplateSelector : DataTemplateSelector
+    {
+        private readonly Dictionary<Type, DataTemplate> selectorDict;
+
+        /// <summary>
+        /// Creates a new ContextAwareDataTemplateSelector
+        /// </summary>
+        public ContextAwareDataTemplateSelector()
+        {
+            selectorDict = new Dictionary<Type, DataTemplate>();
+        }
+
+        /// <summary>
+        /// Determine which DataTemplate to return based on the viewModel, 
+        /// construct the View and wire them together
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="container"></param>
+        /// <returns></returns>
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            Type vmType = item.GetType();
+
+            DataTemplate dataTemplate;
+
+            // Check if DataTemplate for given type has already been created
+            if (!selectorDict.TryGetValue(vmType, out dataTemplate))
+            {
+                Type viewType = ViewLocator.LocateTypeForModelType(vmType, null, null);
+
+                dataTemplate = new DataTemplate(() =>
+                {
+                    // Create the page
+                    var view = Activator.CreateInstance(viewType);
+
+                    var bindableObject = view as BindableObject;
+
+                    if (bindableObject != null)
+                    {
+                        // Once the binding context changes attach view to viewModel
+                        bindableObject.BindingContextChanged += (sender, args) =>
+                        {
+                            var page = sender as Page;
+
+                            var viewAware = page?.BindingContext as IViewAware;
+
+                            viewAware?.AttachView(page);
+                        };
+                    }
+
+                    return view;
+                });
+
+                // Cache created DataTemplate
+                selectorDict.Add(vmType, dataTemplate);
+            }
+
+            return dataTemplate;
+        }
+    }
+}


### PR DESCRIPTION
This PR is regarding adding a DataTemplateSelector that will resolve views based on the viewModel and wire them together (Xamarin.Froms has added DataTemplateSelectors as of verison 2.1.0 ).

Background: Building an app using Xamarin.Forms.TabbedPage resulted in adding child views in XAML and wiring them up manually. Created this DataTemplateSelector to help with that and it works well with the conductors. Thanks