### PR TITLE
Optionally UI Thread property change marshalling

### DIFF
--- a/src/Caliburn.Micro/PropertyChangedBase.cs
+++ b/src/Caliburn.Micro/PropertyChangedBase.cs
@@ -10,6 +10,11 @@
     [DataContract]
     public class PropertyChangedBase : INotifyPropertyChangedEx {
         /// <summary>
+        /// True to marshal NotifyOfPropertyChange calls to the UI thread
+        /// </summary>
+        public static bool MarshalOnUIThread = true;
+        
+        /// <summary>
         /// Creates an instance of <see cref = "PropertyChangedBase" />.
         /// </summary>
         public PropertyChangedBase() {
@@ -44,7 +49,10 @@
         public virtual void NotifyOfPropertyChange([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) {
 #endif
             if (IsNotifying && PropertyChanged != null) {
-                Execute.OnUIThread(() => OnPropertyChanged(new PropertyChangedEventArgs(propertyName)));
+                if(MarshalOnUIThread)
+                    Execute.OnUIThread(() => OnPropertyChanged(new PropertyChangedEventArgs(propertyName)));
+                else
+                    OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
             }
         }
 


### PR DESCRIPTION
When combining property change notification with reactive observables there are situations where is desirable that the property change event is leaved as-is, on its original thread.

Since WPF already does UI Thread marshaling on bindings, would be useful to be able to turn off this behavior.