### PR TITLE
Change the default view creation through DI and/or by directly calling Activator.CreateInstance

### DIFF
--- a/src/Caliburn.Micro.Platform/ViewCantBeCreatedException.cs
+++ b/src/Caliburn.Micro.Platform/ViewCantBeCreatedException.cs
@@ -1,0 +1,8 @@
+﻿namespace Caliburn.Micro {
+using System;
+
+    public class ViewCantBeCreatedException: Exception {
+        public ViewCantBeCreatedException(string message) : base(message) {
+        }
+    }
+}

--- a/src/Caliburn.Micro.Platform/ViewCreationBehavior.enum.cs
+++ b/src/Caliburn.Micro.Platform/ViewCreationBehavior.enum.cs
@@ -17,26 +17,4 @@
         /// </summary>
         DontUseDi,
     }
-
-
-    public class ViewCreationConfiguration {
-
-        public ViewCreationConfiguration() {
-            this.ViewCreationBehavior = ViewCreationBehavior.UseDIContainer;
-        }
-
-        /// <summary>
-        /// Determines how views are created
-        /// The default is to make a callback where you can hook a DI container
-        /// </summary>
-        public ViewCreationBehavior ViewCreationBehavior { get; set; }
-
-        /// <summary>
-        /// Determines how CM reacts when creation fails. 
-        /// When <see langword="true" an empty view is shown with a single text explaining the problem
-        /// When <see langword="false" an exception is thrown. This is the default
-        /// </summary>
-        public bool ShowEmptyViewWhenCreationFailed { get; set; }
-
-    }
 }

--- a/src/Caliburn.Micro.Platform/ViewCreationConfiguration.cs
+++ b/src/Caliburn.Micro.Platform/ViewCreationConfiguration.cs
@@ -1,0 +1,40 @@
+namespace Caliburn.Micro
+{
+    public class ViewCreationConfiguration
+    {
+
+        /// <summary>
+        /// Creates a default ViewCreationConfiguration
+        /// This uses a IoC.GetInstance() to create a view and throws an exception if creation fails
+        /// </summary>
+        public ViewCreationConfiguration() : this(ViewCreationBehavior.UseDIContainer)
+        {
+        }
+
+        /// <summary>
+        /// Creates a view configuration given a certain <see cref="ViewCreationBehavior"/> 
+        /// When <see cref="ViewCreationBehavior.UseV3StyleLocation"/> is used, <see cref="ShowEmptyViewWhenCreationFailed"/> will default to <see langword="true"/>
+        /// </summary>
+        /// <param name="viewCreationBehavior">The behavior to create views</param>
+        public ViewCreationConfiguration(ViewCreationBehavior viewCreationBehavior)
+        {
+            this.ViewCreationBehavior = viewCreationBehavior;
+
+            this.ShowEmptyViewWhenCreationFailed = viewCreationBehavior == ViewCreationBehavior.UseV3StyleLocation;
+        }
+
+        /// <summary>
+        /// Determines how views are created
+        /// The default is to make a callback where you can hook a DI container
+        /// </summary>
+        public ViewCreationBehavior ViewCreationBehavior { get; set; }
+
+        /// <summary>
+        /// Determines how CM reacts when creation fails. 
+        /// When <see langword="true"/> an empty view is shown with a single text explaining the problem. This is the default when using V3Style viewcreation
+        /// When <see langword="false"/> an exception is thrown. This is the default
+        /// </summary>
+        public bool ShowEmptyViewWhenCreationFailed { get; set; }
+
+    }
+}

--- a/src/Caliburn.Micro.Platform/ViewLocationConfiguration.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocationConfiguration.cs
@@ -1,0 +1,42 @@
+﻿namespace Caliburn.Micro {
+
+    public enum ViewCreationBehavior {
+        /// <summary>
+        /// This is the default location type.
+        /// A callback is done to the C.M. root app instance.GetInstance(), when null is returned
+        /// C.M. tries to create the view using <see cref="System.Activator"/>.
+        /// </summary>
+        UseDIContainer,
+        /// <summary>
+        /// A callback is done to the C.M. root app instance.GetAllInstances(), when null is returned
+        /// C.M. tries to create the view using <see cref="System.Activator"/>.
+        /// </summary>
+        UseV3StyleLocation,
+        /// <summary>
+        /// The CM root app instance isn't called. CM just creates the view using <see cref="System.Activator"/>.
+        /// </summary>
+        DontUseDi,
+    }
+
+
+    public class ViewCreationConfiguration {
+
+        public ViewCreationConfiguration() {
+            this.ViewCreationBehavior = ViewCreationBehavior.UseDIContainer;
+        }
+
+        /// <summary>
+        /// Determines how views are created
+        /// The default is to make a callback where you can hook a DI container
+        /// </summary>
+        public ViewCreationBehavior ViewCreationBehavior { get; set; }
+
+        /// <summary>
+        /// Determines how CM reacts when creation fails. 
+        /// When <see langword="true" an empty view is shown with a single text explaining the problem
+        /// When <see langword="false" an exception is thrown. This is the default
+        /// </summary>
+        public bool ShowEmptyViewWhenCreationFailed { get; set; }
+
+    }
+}

--- a/src/Caliburn.Micro.Platform/ViewLocator.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocator.cs
@@ -108,7 +108,7 @@ namespace Caliburn.Micro
         /// You can change this behavior by adjusting the configuration.
         /// </summary>
         /// <param name="config">An instance of <see cref="ViewCreationConfiguration"/> that provides the settings for configuration</param>
-        public static void ConfigureViewLocation(ViewCreationConfiguration config)
+        public static void ConfigureViewCreation(ViewCreationConfiguration config)
         {
             if (config == null)
             {
@@ -333,8 +333,7 @@ namespace Caliburn.Micro
 
         private static UIElement GetOrCreateViewTypeV3Style(Type viewType)
         {
-            var view = IoC.GetAllInstances(viewType)
-                .FirstOrDefault() as UIElement;
+            var view = IoC.GetAllInstances(viewType)?.FirstOrDefault() as UIElement;
 
             return view!= null
             ? InitializeAndReturnView(view)

--- a/src/Caliburn.Micro.Platform/ViewLocator.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocator.cs
@@ -29,7 +29,8 @@ namespace Caliburn.Micro
     /// <summary>
     ///   A strategy for determining which view to use for a given model.
     /// </summary>
-    public static class ViewLocator {
+    public static class ViewLocator
+    {
         static readonly ILog Log = LogManager.GetLog(typeof(ViewLocator));
 
         //These fields are used for configuring the default type mappings. They can be changed using ConfigureTypeMappings().
@@ -41,6 +42,9 @@ namespace Caliburn.Micro
         static readonly List<string> ViewSuffixList = new List<string>();
         static bool includeViewSuffixInVmNames;
 
+        // This is the configuration of how viewlocation behaves
+        private static ViewCreationConfiguration viewCreationConfiguration;
+
         ///<summary>
         /// Used to transform names.
         ///</summary>
@@ -51,8 +55,11 @@ namespace Caliburn.Micro
         /// </summary>
         public static string ContextSeparator = ".";
 
-        static ViewLocator() {
+        static ViewLocator()
+        {
             ConfigureTypeMappings(new TypeMappingConfiguration());
+
+            ViewLocator.viewCreationConfiguration = new ViewCreationConfiguration();
         }
 
         /// <summary>
@@ -61,16 +68,20 @@ namespace Caliburn.Micro
         /// configuration.
         /// </summary>
         /// <param name="config">An instance of TypeMappingConfiguration that provides the settings for configuration</param>
-        public static void ConfigureTypeMappings(TypeMappingConfiguration config) {
-            if (String.IsNullOrEmpty(config.DefaultSubNamespaceForViews)) {
+        public static void ConfigureTypeMappings(TypeMappingConfiguration config)
+        {
+            if (String.IsNullOrEmpty(config.DefaultSubNamespaceForViews))
+            {
                 throw new ArgumentException("DefaultSubNamespaceForViews field cannot be blank.");
             }
 
-            if (String.IsNullOrEmpty(config.DefaultSubNamespaceForViewModels)) {
+            if (String.IsNullOrEmpty(config.DefaultSubNamespaceForViewModels))
+            {
                 throw new ArgumentException("DefaultSubNamespaceForViewModels field cannot be blank.");
             }
 
-            if (String.IsNullOrEmpty(config.NameFormat)) {
+            if (String.IsNullOrEmpty(config.NameFormat))
+            {
                 throw new ArgumentException("NameFormat field cannot be blank.");
             }
 
@@ -88,13 +99,34 @@ namespace Caliburn.Micro
             SetAllDefaults();
         }
 
+        /// <summary>
+        /// Specifies how views will be created.
+        /// By default viewlocation is done by calling IoC.GetInstance which you can use to supply the view
+        /// from a DI container of your choice. If you return <see langword="null"/> Caliburn will try to create
+        /// the view for you. Exception handling however should be done by yourself! If Caliburn is also unable to
+        /// create the view, an exception is raised 
+        /// You can change this behavior by adjusting the configuration.
+        /// </summary>
+        /// <param name="config">An instance of <see cref="ViewCreationConfiguration"/> that provides the settings for configuration</param>
+        public static void ConfigureViewLocation(ViewCreationConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
 
-        private static void SetAllDefaults() {
-            if (useNameSuffixesInMappings) {
+            ViewLocator.viewCreationConfiguration = config;
+        }
+
+        private static void SetAllDefaults()
+        {
+            if (useNameSuffixesInMappings)
+            {
                 //Add support for all view suffixes
                 ViewSuffixList.Apply(AddDefaultTypeMapping);
             }
-            else {
+            else
+            {
                 AddSubNamespaceMapping(defaultSubNsViewModels, defaultSubNsViews);
             }
         }
@@ -103,8 +135,10 @@ namespace Caliburn.Micro
         /// Adds a default type mapping using the standard namespace mapping convention
         /// </summary>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddDefaultTypeMapping(string viewSuffix = "View") {
-            if (!useNameSuffixesInMappings) {
+        public static void AddDefaultTypeMapping(string viewSuffix = "View")
+        {
+            if (!useNameSuffixesInMappings)
+            {
                 return;
             }
 
@@ -122,8 +156,10 @@ namespace Caliburn.Micro
         /// is added directly through the NameTransformer.
         /// </summary>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View".</param>
-        public static void RegisterViewSuffix(string viewSuffix) {
-            if (ViewSuffixList.Count(s => s == viewSuffix) == 0) {
+        public static void RegisterViewSuffix(string viewSuffix)
+        {
+            if (ViewSuffixList.Count(s => s == viewSuffix) == 0)
+            {
                 ViewSuffixList.Add(viewSuffix);
             }
         }
@@ -135,22 +171,26 @@ namespace Caliburn.Micro
         /// <param name="nsSourceFilterRegEx">RegEx filter pattern for source namespace</param>
         /// <param name="nsTargetsRegEx">Array of RegEx replace values for target namespaces</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddTypeMapping(string nsSourceReplaceRegEx, string nsSourceFilterRegEx, string[] nsTargetsRegEx, string viewSuffix = "View") {
+        public static void AddTypeMapping(string nsSourceReplaceRegEx, string nsSourceFilterRegEx, string[] nsTargetsRegEx, string viewSuffix = "View")
+        {
             RegisterViewSuffix(viewSuffix);
 
             var replist = new List<string>();
             var repsuffix = useNameSuffixesInMappings ? viewSuffix : String.Empty;
             const string basegrp = "${basename}";
 
-            foreach (var t in nsTargetsRegEx) {
+            foreach (var t in nsTargetsRegEx)
+            {
                 replist.Add(t + String.Format(nameFormat, basegrp, repsuffix));
             }
 
             var rxbase = RegExHelper.GetNameCaptureGroup("basename");
             var suffix = String.Empty;
-            if (useNameSuffixesInMappings) {
+            if (useNameSuffixesInMappings)
+            {
                 suffix = viewModelSuffix;
-                if (!viewModelSuffix.Contains(viewSuffix) && includeViewSuffixInVmNames) {
+                if (!viewModelSuffix.Contains(viewSuffix) && includeViewSuffixInVmNames)
+                {
                     suffix = viewSuffix + suffix;
                 }
             }
@@ -173,7 +213,8 @@ namespace Caliburn.Micro
         /// <param name="nsSourceFilterRegEx">RegEx filter pattern for source namespace</param>
         /// <param name="nsTargetRegEx">RegEx replace value for target namespace</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddTypeMapping(string nsSourceReplaceRegEx, string nsSourceFilterRegEx, string nsTargetRegEx, string viewSuffix = "View") {
+        public static void AddTypeMapping(string nsSourceReplaceRegEx, string nsSourceFilterRegEx, string nsTargetRegEx, string viewSuffix = "View")
+        {
             AddTypeMapping(nsSourceReplaceRegEx, nsSourceFilterRegEx, new[] { nsTargetRegEx }, viewSuffix);
         }
 
@@ -183,13 +224,15 @@ namespace Caliburn.Micro
         /// <param name="nsSource">Namespace of source type</param>
         /// <param name="nsTargets">Namespaces of target type as an array</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddNamespaceMapping(string nsSource, string[] nsTargets, string viewSuffix = "View") {
+        public static void AddNamespaceMapping(string nsSource, string[] nsTargets, string viewSuffix = "View")
+        {
             //need to terminate with "." in order to concatenate with type name later
             var nsencoded = RegExHelper.NamespaceToRegEx(nsSource + ".");
 
             //Start pattern search from beginning of string ("^")
             //unless original string was blank (i.e. special case to indicate "append target to source")
-            if (!String.IsNullOrEmpty(nsSource)) {
+            if (!String.IsNullOrEmpty(nsSource))
+            {
                 nsencoded = "^" + nsencoded;
             }
 
@@ -206,7 +249,8 @@ namespace Caliburn.Micro
         /// <param name="nsSource">Namespace of source type</param>
         /// <param name="nsTarget">Namespace of target type</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddNamespaceMapping(string nsSource, string nsTarget, string viewSuffix = "View") {
+        public static void AddNamespaceMapping(string nsSource, string nsTarget, string viewSuffix = "View")
+        {
             AddNamespaceMapping(nsSource, new[] { nsTarget }, viewSuffix);
         }
 
@@ -216,7 +260,8 @@ namespace Caliburn.Micro
         /// <param name="nsSource">Subnamespace of source type</param>
         /// <param name="nsTargets">Subnamespaces of target type as an array</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddSubNamespaceMapping(string nsSource, string[] nsTargets, string viewSuffix = "View") {
+        public static void AddSubNamespaceMapping(string nsSource, string[] nsTargets, string viewSuffix = "View")
+        {
             //need to terminate with "." in order to concatenate with type name later
             var nsencoded = RegExHelper.NamespaceToRegEx(nsSource + ".");
 
@@ -225,12 +270,14 @@ namespace Caliburn.Micro
 
             if (!String.IsNullOrEmpty(nsSource))
             {
-                if (!nsSource.StartsWith("*")) {
+                if (!nsSource.StartsWith("*"))
+                {
                     rxbeforesrc = RegExHelper.GetNamespaceCaptureGroup("nsbefore");
                     rxbeforetgt = @"${nsbefore}";
                 }
 
-                if (!nsSource.EndsWith("*")) {
+                if (!nsSource.EndsWith("*"))
+                {
                     rxaftersrc = RegExHelper.GetNamespaceCaptureGroup("nsafter");
                     rxaftertgt = "${nsafter}";
                 }
@@ -249,7 +296,8 @@ namespace Caliburn.Micro
         /// <param name="nsSource">Subnamespace of source type</param>
         /// <param name="nsTarget">Subnamespace of target type</param>
         /// <param name="viewSuffix">Suffix for type name. Should  be "View" or synonym of "View". (Optional)</param>
-        public static void AddSubNamespaceMapping(string nsSource, string nsTarget, string viewSuffix = "View") {
+        public static void AddSubNamespaceMapping(string nsSource, string nsTarget, string viewSuffix = "View")
+        {
             AddSubNamespaceMapping(nsSource, new[] { nsTarget }, viewSuffix);
         }
 
@@ -259,39 +307,104 @@ namespace Caliburn.Micro
         /// <remarks>
         ///   Pass the type of view as a parameter and recieve an instance of the view.
         /// </remarks>
-        public static Func<Type, UIElement> GetOrCreateViewType = viewType => {
-            var view = IoC.GetAllInstances(viewType)
-                           .FirstOrDefault() as UIElement;
+        public static Func<Type, UIElement> GetOrCreateViewType = viewType =>
+        {
+            switch (ViewLocator.viewCreationConfiguration.ViewCreationBehavior)
+            {
+                case ViewCreationBehavior.UseDIContainer:
+                    return ViewLocator.GetOrCreateViewFromDIContainer(viewType);
+                case ViewCreationBehavior.UseV3StyleLocation:
+                    return ViewLocator.GetOrCreateViewTypeV3Style(viewType);
+                case ViewCreationBehavior.DontUseDi:
+                    return ViewLocator.CreateView(viewType);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(ViewLocator.viewCreationConfiguration.ViewCreationBehavior));
+            }
+        };
 
-            if (view != null) {
-                InitializeComponent(view);
-                return view;
+        private static UIElement GetOrCreateViewFromDIContainer(Type viewType)
+        {
+            var view = IoC.GetInstance(viewType, null) as UIElement;
+
+            return view != null
+                ? InitializeAndReturnView(view)
+                : CreateView(viewType);
+        }
+
+        private static UIElement GetOrCreateViewTypeV3Style(Type viewType)
+        {
+            var view = IoC.GetAllInstances(viewType)
+                .FirstOrDefault() as UIElement;
+
+            return view!= null
+            ? InitializeAndReturnView(view)
+            : CreateView(viewType);
+        }
+
+        private static UIElement CreateView(Type viewType) {
+            var result = ViewLocator.CanWeCreateTheView(viewType);
+
+            if (result.ViewIsCreatable) {
+                var view = (UIElement) System.Activator.CreateInstance(viewType);
+
+                return InitializeAndReturnView(view);
             }
 
+            if (ViewLocator.viewCreationConfiguration.ShowEmptyViewWhenCreationFailed) {
 #if !WINDOWS_UWP && !XFORMS
-            if (viewType.IsInterface || viewType.IsAbstract || !typeof(UIElement).IsAssignableFrom(viewType))
-                return new TextBlock { Text = string.Format("Cannot create {0}.", viewType.FullName) };
+                return new TextBlock { Text = result.Message };
 #else
+                return new TextBlock { Text = result.Message };
+#endif                
+            }
+
+            throw new ViewCantBeCreatedException(result.Message);
+        }
+
+        private static ViewCreatableResult CanWeCreateTheView(Type viewType) {
+
             var viewTypeInfo = viewType.GetTypeInfo();
+
+#if !WINDOWS_UWP && !XFORMS
             var uiElementInfo = typeof(UIElement).GetTypeInfo();
-
-            if (viewTypeInfo.IsInterface || viewTypeInfo.IsAbstract || !uiElementInfo.IsAssignableFrom(viewTypeInfo))
-                return new TextBlock { Text = string.Format("Cannot create {0}.", viewType.FullName) };
+#else
+            var uiElementInfo = typeof(UIElement).GetTypeInfo();
 #endif
+            if (viewTypeInfo.IsInterface || viewTypeInfo.IsAbstract || !uiElementInfo.IsAssignableFrom(viewTypeInfo)) {
+                return new ViewCreatableResult(viewIsCreatable: false,
+                    message: $"Cannot create {viewType.FullName} because the type is abstract or not of type `UIElement`.");
+            }
 
-            view = (UIElement)System.Activator.CreateInstance(viewType);
+            var constructors = (
+                from ctor in viewTypeInfo.DeclaredConstructors
+                where ctor.IsPublic
+                select new
+                {
+                    NumberOfParameters = ctor.GetParameters().Length,
+                }).ToArray();
 
+            if (constructors.Length != 1 || constructors.Single().NumberOfParameters != 0) {
+                return new ViewCreatableResult(viewIsCreatable: false,
+                    message: $"Cannot create {viewType.FullName} because the type has no default public constructor. Multiple constructors are not supported!");
+            }
+
+            return new ViewCreatableResult(true);
+        }
+
+        private static UIElement InitializeAndReturnView(UIElement view)
+        {
             InitializeComponent(view);
 
             return view;
-        };
+        }
 
         /// <summary>
         /// Modifies the name of the type to be used at design time.
         /// </summary>
         public static Func<string, string> ModifyModelTypeAtDesignTime = modelTypeName =>
         {
-            if (modelTypeName.StartsWith("_")) {
+            if (modelTypeName.StartsWith("_"))
+            {
                 var index = modelTypeName.IndexOf('.');
                 modelTypeName = modelTypeName.Substring(index + 1);
                 index = modelTypeName.IndexOf('.');
@@ -310,16 +423,19 @@ namespace Caliburn.Micro
         /// typeName = The name of the ViewModel type being resolved to its companion View.
         /// context = An instance of the context or null.
         /// </remarks>
-        public static Func<string, object, IEnumerable<string>> TransformName = (typeName, context) => {
+        public static Func<string, object, IEnumerable<string>> TransformName = (typeName, context) =>
+        {
             Func<string, string> getReplaceString;
-            if (context == null) {
+            if (context == null)
+            {
                 getReplaceString = r => r;
                 return NameTransformer.Transform(typeName, getReplaceString);
             }
 
             var contextstr = ContextSeparator + context;
             string grpsuffix = String.Empty;
-            if (useNameSuffixesInMappings) {
+            if (useNameSuffixesInMappings)
+            {
                 //Create RegEx for matching any of the synonyms registered
                 var synonymregex = "(" + String.Join("|", ViewSuffixList.ToArray()) + ")";
                 grpsuffix = RegExHelper.GetCaptureGroup("suffix", synonymregex);
@@ -345,10 +461,12 @@ namespace Caliburn.Micro
         /// <remarks>
         ///   Pass the model type, display location (or null) and the context instance (or null) as parameters and receive a view type.
         /// </remarks>
-        public static Func<Type, DependencyObject, object, Type> LocateTypeForModelType = (modelType, displayLocation, context) => {
+        public static Func<Type, DependencyObject, object, Type> LocateTypeForModelType = (modelType, displayLocation, context) =>
+        {
             var viewTypeName = modelType.FullName;
 
-            if (View.InDesignMode) {
+            if (View.InDesignMode)
+            {
                 viewTypeName = ModifyModelTypeAtDesignTime(viewTypeName);
             }
 
@@ -362,7 +480,8 @@ namespace Caliburn.Micro
             var viewTypeList = TransformName(viewTypeName, context);
             var viewType = AssemblySource.FindTypeByNames(viewTypeList);
 
-            if (viewType == null) {
+            if (viewType == null)
+            {
                 Log.Warn("View not found. Searched: {0}.", string.Join(", ", viewTypeList.ToArray()));
             }
 
@@ -376,7 +495,8 @@ namespace Caliburn.Micro
         /// <remarks>
         ///   Pass the model type, display location (or null) and the context instance (or null) as parameters and receive a view instance.
         /// </remarks>
-        public static Func<Type, DependencyObject, object, UIElement> LocateForModelType = (modelType, displayLocation, context) => {
+        public static Func<Type, DependencyObject, object, UIElement> LocateForModelType = (modelType, displayLocation, context) =>
+        {
             var viewType = LocateTypeForModelType(modelType, displayLocation, context);
 
             return viewType == null
@@ -391,14 +511,18 @@ namespace Caliburn.Micro
         /// <remarks>
         ///   Pass the model instance, display location (or null) and the context (or null) as parameters and receive a view instance.
         /// </remarks>
-        public static Func<object, DependencyObject, object, UIElement> LocateForModel = (model, displayLocation, context) => {
+        public static Func<object, DependencyObject, object, UIElement> LocateForModel = (model, displayLocation, context) =>
+        {
             var viewAware = model as IViewAware;
-            if (viewAware != null) {
+            if (viewAware != null)
+            {
                 var view = viewAware.GetView(context) as UIElement;
-                if (view != null) {
+                if (view != null)
+                {
 #if !WINDOWS_UWP && !XFORMS
                     var windowCheck = view as Window;
-                    if (windowCheck == null || (!windowCheck.IsLoaded && !(new WindowInteropHelper(windowCheck).Handle == IntPtr.Zero))) {
+                    if (windowCheck == null || (!windowCheck.IsLoaded && !(new WindowInteropHelper(windowCheck).Handle == IntPtr.Zero)))
+                    {
                         Log.Info("Using cached view for {0}.", model);
                         return view;
                     }
@@ -415,7 +539,8 @@ namespace Caliburn.Micro
         /// <summary>
         /// Transforms a view type into a pack uri.
         /// </summary>
-        public static Func<Type, Type, string> DeterminePackUriFromType = (viewModelType, viewType) => {
+        public static Func<Type, Type, string> DeterminePackUriFromType = (viewModelType, viewType) =>
+        {
 #if !WINDOWS_UWP && !XFORMS
             var assemblyName = viewType.Assembly.GetAssemblyName();
             var applicationAssemblyName = Application.Current.GetType().Assembly.GetAssemblyName();
@@ -430,7 +555,8 @@ namespace Caliburn.Micro
 
             var uri = viewTypeName.Replace(".", "/") + ".xaml";
 
-            if(!applicationAssemblyName.Equals(assemblyName)) {
+            if (!applicationAssemblyName.Equals(assemblyName))
+            {
                 return "/" + assemblyName + ";component" + uri;
             }
 
@@ -441,7 +567,8 @@ namespace Caliburn.Micro
         ///   When a view does not contain a code-behind file, we need to automatically call InitializeCompoent.
         /// </summary>
         /// <param name = "element">The element to initialize</param>
-        public static void InitializeComponent(object element) {
+        public static void InitializeComponent(object element)
+        {
 #if XFORMS
             return;
 #elif !WINDOWS_UWP
@@ -456,6 +583,21 @@ namespace Caliburn.Micro
 
             method?.Invoke(element, null);
 #endif
+        }
+
+        private class ViewCreatableResult {
+            public ViewCreatableResult(bool viewIsCreatable, string message = null) {
+                if (!viewIsCreatable && message == null) {
+                    throw new InvalidOperationException("If we can't create the view, please supply a valid " +
+                                                        "message for the user!");
+                }
+
+                this.ViewIsCreatable = viewIsCreatable;
+                this.Message = message;
+            }
+        
+            public bool ViewIsCreatable { get; }
+            public string Message { get; }
         }
     }
 }

--- a/src/Caliburn.Micro.Tests.NET45/Caliburn.Micro.Tests.NET45.csproj
+++ b/src/Caliburn.Micro.Tests.NET45/Caliburn.Micro.Tests.NET45.csproj
@@ -60,12 +60,15 @@
     <Compile Include="EventAggregatorTests.cs" />
     <Compile Include="IoCTests.cs" />
     <Compile Include="MessageBinderTests.cs" />
+    <Compile Include="MockClasses\MyView.cs" />
+    <Compile Include="MockClasses\MyViewWithDependencies.cs" />
     <Compile Include="RegExHelperTests.cs" />
     <Compile Include="ScopeNamingRouteTests.cs" />
     <Compile Include="ConductorWithCollectionOneActiveTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleContainerTests.cs" />
     <Compile Include="StringSplitterTests.cs" />
+    <Compile Include="ViewCreationTests.cs" />
     <Compile Include="ViewLocatorTests.cs" />
     <Compile Include="ViewModelLocatorTests.cs" />
   </ItemGroup>

--- a/src/Caliburn.Micro.Tests.NET45/MockClasses/MyView.cs
+++ b/src/Caliburn.Micro.Tests.NET45/MockClasses/MyView.cs
@@ -1,0 +1,7 @@
+﻿using System.Windows;
+
+namespace Caliburn.Micro.Tests.NET45.MockClasses {
+    public class MyView:Window {
+        
+    }
+}

--- a/src/Caliburn.Micro.Tests.NET45/MockClasses/MyViewWithDependencies.cs
+++ b/src/Caliburn.Micro.Tests.NET45/MockClasses/MyViewWithDependencies.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Caliburn.Micro.Tests.NET45.MockClasses {
+    public class MyViewWithDependencies : Window
+    {
+        public MyViewWithDependencies(MyViewModel viewModel) {
+            
+        }
+    }
+    
+    public class MyViewModel { }
+}

--- a/src/Caliburn.Micro.Tests.NET45/ViewCreationTests.cs
+++ b/src/Caliburn.Micro.Tests.NET45/ViewCreationTests.cs
@@ -1,0 +1,187 @@
+﻿using System.Windows.Controls;
+using Caliburn.Micro.Tests.NET45.MockClasses;
+
+namespace Caliburn.Micro.Tests.NET45 {
+    using Xunit;
+    using System;
+
+    public class ViewCreationTests {
+
+        [Fact]
+        public void DefaultViewCreationConfigShouldCallGetInstance() {
+            // Arrange
+            bool iocIscalled = false;
+            IoC.GetInstance = (type, s) => {
+                iocIscalled = true;
+                return null;
+            };
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration());
+            
+            // Act
+            ViewLocator.GetOrCreateViewType(typeof(MyView));
+
+            // Assert
+            Assert.True(iocIscalled);
+        }
+
+        [Fact]
+        public void DefaultViewCreationConfigShouldNotCallGetAllInstances()
+        {
+            // Arrange
+            bool iocIscalled = false;
+            IoC.GetAllInstances = (type) => {
+                iocIscalled = true;
+                return null;
+            };
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration());
+
+            // Act
+            ViewLocator.GetOrCreateViewType(typeof(MyView));
+
+            // Assert
+            Assert.False(iocIscalled);
+        }
+
+        [Fact]
+        public void DefaultViewCreationConfigWithConstructorParameterThrows() {
+            // Arrange
+            IoC.GetInstance = (type, s) => null;
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration());
+
+            // Assert
+            Assert.Throws<ViewCantBeCreatedException>(() => ViewLocator.GetOrCreateViewType(typeof(MyViewWithDependencies)));
+        }
+
+        [Fact]
+        public void DefaultViewCreationConfigWithConstructorParameterIsCreatedByIocSucceeds()
+        {
+            // Arrange
+            IoC.GetInstance = (type, s) => new MyViewWithDependencies(new MyViewModel());
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration());
+
+            object view = null;
+
+            // Assert
+            Assert.DoesNotThrow(() => view = ViewLocator.GetOrCreateViewType(typeof(MyViewWithDependencies)));
+            Assert.NotNull(view);
+            Assert.IsType<MyViewWithDependencies>(view);
+        }
+
+        [Fact]
+        public void DefaultViewCreationConfigIoCThrowsReachesUser()
+        {
+            // Arrange
+            IoC.GetInstance = (type, s) => throw new InvalidOperationException($"{type.FullName} could not be created!");
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration());
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => ViewLocator.GetOrCreateViewType(typeof(MyViewWithDependencies)));
+        }
+
+        [Fact]
+        public void ViewCreationConfigShowEmptyWithConstructorParameterReturnsEmptyView()
+        {
+            // Arrange
+            IoC.GetInstance = (type, s) => null;
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration { ShowEmptyViewWhenCreationFailed = true});
+
+            object view = null;
+
+            // Assert
+            Assert.DoesNotThrow(() => view = ViewLocator.GetOrCreateViewType(typeof(MyViewWithDependencies)));
+            Assert.NotNull(view);
+            Assert.IsType<TextBlock>(view);
+        }
+
+        [Fact]
+        public void V3StyleViewConfigurationShowsEmptyViewByDefault() {
+            // Arrange
+            var config = new ViewCreationConfiguration(ViewCreationBehavior.UseV3StyleLocation);
+
+            // Assert
+            Assert.True(config.ShowEmptyViewWhenCreationFailed);
+        }
+
+        [Fact]
+        public void V3StyleConfigCallsGetAllInstances() {
+            // Arrange
+            bool iocCalled = false;
+            IoC.GetAllInstances = type => {
+                iocCalled = true;
+                return null;
+            };
+
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration(ViewCreationBehavior.UseV3StyleLocation));
+
+            // Act
+            ViewLocator.GetOrCreateViewType(typeof(MyView));
+
+            // Assert
+            Assert.True(iocCalled);
+        }
+
+        [Fact]
+        public void V3StyleConfigDontCallsGetInstance()
+        {
+            // Arrange
+            bool iocCalled = false;
+            IoC.GetInstance = (type,s) => {
+                iocCalled = true;
+                return null;
+            };
+
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration(ViewCreationBehavior.UseV3StyleLocation));
+
+            // Act
+            ViewLocator.GetOrCreateViewType(typeof(MyView));
+
+            // Assert
+            Assert.False(iocCalled);
+        }
+
+        [Fact]
+        public void DontUseDiContainerConfigDoesNotCallIoc() {
+            // Arrange
+            bool iocCalled = false;
+            IoC.GetInstance = (type, s) => {
+                iocCalled = true;
+                return null;
+            };
+            IoC.GetAllInstances= (type) => {
+                iocCalled = true;
+                return null;
+            };
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration(ViewCreationBehavior.DontUseDi));
+
+            // Act
+            ViewLocator.GetOrCreateViewType(typeof(MyView));
+
+            // Assert
+            Assert.False(iocCalled);
+        }
+
+        [Fact]
+        public void ViewCreationFailsWithExpectedMessageNoDefaultConstructor()
+        {
+            // Arrange
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration(ViewCreationBehavior.DontUseDi));
+
+            // Assert
+            var exception = Assert.Throws<ViewCantBeCreatedException>(() => 
+                        ViewLocator.GetOrCreateViewType(typeof(MyViewWithDependencies)));
+            Assert.Contains("because the type has no default public constructor.", exception.Message);
+        }
+
+        [Fact]
+        public void ViewCreationFailsWithExpectedMessageNoUIElement()
+        {
+            // Arrange
+            ViewLocator.ConfigureViewCreation(new ViewCreationConfiguration(ViewCreationBehavior.DontUseDi));
+
+            // Assert
+            var exception = Assert.Throws<ViewCantBeCreatedException>(() =>
+                ViewLocator.GetOrCreateViewType(typeof(MyViewModel)));
+            Assert.Contains("because the type is abstract or not of type `UIElement`", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
These changes change the manner in how C.M. creates view as discussed in #339.

The defaults are open for discussing. 

I chose the defaults in how I would like the framework to react. I can't determine this for other users although this implementation is much more towards 'fail fast' as we see many frameworks do nowadays.

Also added unittests for net45.

Although the project builds successfully for some reason it keeps complaining in the IDE that it is missing references to `System` when I select .netstandard1.4. So I can't really see if this code (for x.f.) really will work. We'll have to test that in a x.f. application I think.

Let me know what you think.
