### PR TITLE
Use explicit title for windows and pages

### DIFF
--- a/src/Caliburn.Micro.Platform/net40/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/net40/WindowManager.cs
@@ -142,7 +142,7 @@
             ViewModelBinder.Bind(rootModel, view, context);
 
             var haveDisplayName = rootModel as IHaveDisplayName;
-            if (haveDisplayName != null && !ConventionManager.HasBinding(view, Window.TitleProperty)) {
+            if (string.IsNullOrEmpty(view.Title) && haveDisplayName != null && !ConventionManager.HasBinding(view, Window.TitleProperty)) {
                 var binding = new Binding("DisplayName") { Mode = BindingMode.TwoWay };
                 view.SetBinding(Window.TitleProperty, binding);
             }
@@ -219,7 +219,7 @@
             ViewModelBinder.Bind(rootModel, view, context);
 
             var haveDisplayName = rootModel as IHaveDisplayName;
-            if (haveDisplayName != null && !ConventionManager.HasBinding(view, Page.TitleProperty)) {
+            if (string.IsNullOrEmpty(view.Title) && haveDisplayName != null && !ConventionManager.HasBinding(view, Page.TitleProperty)) {
                 var binding = new Binding("DisplayName") { Mode = BindingMode.TwoWay };
                 view.SetBinding(Page.TitleProperty, binding);
             }

--- a/src/Caliburn.Micro.Platform/sl4/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/sl4/WindowManager.cs
@@ -52,7 +52,7 @@
             ViewModelBinder.Bind(rootModel, view, context);
 
             var haveDisplayName = rootModel as IHaveDisplayName;
-            if(haveDisplayName != null && !ConventionManager.HasBinding(view, ChildWindow.TitleProperty)) {
+            if(string.IsNullOrEmpty(view.Title) && haveDisplayName != null && !ConventionManager.HasBinding(view, ChildWindow.TitleProperty)) {
                 var binding = new Binding("DisplayName") { Mode = BindingMode.TwoWay };
                 view.SetBinding(ChildWindow.TitleProperty, binding);
             }


### PR DESCRIPTION
As discussed in #462 the window title is taken from the window property instead of always using a binding.