### PR TITLE
[Documentation] Fixed spelling of 'Inidicates' with 'Indicates'

### DIFF
--- a/src/Caliburn.Micro/Conductor.cs
+++ b/src/Caliburn.Micro/Conductor.cs
@@ -60,7 +60,7 @@
         /// <summary>
         /// Called when deactivating.
         /// </summary>
-        /// <param name="close">Inidicates whether this instance will be closed.</param>
+        /// <param name="close">Indicates whether this instance will be closed.</param>
         protected override void OnDeactivate(bool close) {
             ScreenExtensions.TryDeactivate(ActiveItem, close);
         }

--- a/src/Caliburn.Micro/ConductorWithCollectionAllActive.cs
+++ b/src/Caliburn.Micro/ConductorWithCollectionAllActive.cs
@@ -65,7 +65,7 @@
                 /// <summary>
                 /// Called when deactivating.
                 /// </summary>
-                /// <param name="close">Inidicates whether this instance will be closed.</param>
+                /// <param name="close">Indicates whether this instance will be closed.</param>
                 protected override void OnDeactivate(bool close) {
                     items.OfType<IDeactivate>().Apply(x => x.Deactivate(close));
                     if (close) {

--- a/src/Caliburn.Micro/ConductorWithCollectionOneActive.cs
+++ b/src/Caliburn.Micro/ConductorWithCollectionOneActive.cs
@@ -170,7 +170,7 @@
                 /// <summary>
                 /// Called when deactivating.
                 /// </summary>
-                /// <param name="close">Inidicates whether this instance will be closed.</param>
+                /// <param name="close">Indicates whether this instance will be closed.</param>
                 protected override void OnDeactivate(bool close) {
                     if (close) {
                         items.OfType<IDeactivate>().Apply(x => x.Deactivate(true));

--- a/src/Caliburn.Micro/Screen.cs
+++ b/src/Caliburn.Micro/Screen.cs
@@ -147,7 +147,7 @@
         /// <summary>
         /// Called when deactivating.
         /// </summary>
-        /// <param name = "close">Inidicates whether this instance will be closed.</param>
+        /// <param name = "close">Indicates whether this instance will be closed.</param>
         protected virtual void OnDeactivate(bool close) {}
 
         /// <summary>


### PR DESCRIPTION
When using a doc generator (such as Ghostdoc) alongside StyleCop, it would import the spelling mistake and Stylecop would keep flagging it up. This would always happen when overriding OnDeactivate.

A trivial thing but it somehow bothered me greatly enough to do this.