### PR TITLE
Update Xamarin.Forms NavigationPageAdapter

### DIFF
--- a/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/xforms/NavigationPageAdapter.cs
@@ -1,9 +1,8 @@
-﻿using System.Reflection;
-
-namespace Caliburn.Micro.Xamarin.Forms {
+﻿namespace Caliburn.Micro.Xamarin.Forms {
 
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Threading.Tasks;
     using global::Xamarin.Forms;
 
@@ -74,13 +73,21 @@ namespace Caliburn.Micro.Xamarin.Forms {
             return page;
         }
 
-        private static void DeactivateView(BindableObject view)
+        /// <summary>
+        /// Apply logic to deactivate the active view when it is popped off the navigation stack
+        /// </summary>
+        /// <param name="view">the previously active view</param>
+        protected virtual void DeactivateView(BindableObject view)
         {
             var deactivate = view?.BindingContext as IDeactivate;
             deactivate?.Deactivate(false);
         }
 
-        private static void ActivateView(BindableObject view)
+        /// <summary>
+        /// Apply logic to activate a view when it is popped onto the navigation stack
+        /// </summary>
+        /// <param name="view">the view to activate</param>
+        protected virtual void ActivateView(BindableObject view)
         {
             var activate = view?.BindingContext as IActivate;
             activate?.Activate();


### PR DESCRIPTION
This is a small tweak to the Xamarin.Forms NavigationPageAdapter to allow users to apply additional logic when a page is pushed or popped from the navigation stack.

As an example, I have a cross-cutting concern for network connectivity in my application. Users are able to navigate while offline, but I need a visual indicator on each page to show connectivity. Rather than have all pages in the application query the network status on activation, it would be ideal if the network status was provided to them externally as they navigated. With this PR I can subclass NavigationPageAdapter to provide status when pages are pushed/popped. 