### PR TITLE
[WIP] Fix for InvalidOperationException when iOS app starts

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/FormsApplication.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/FormsApplication.cs
@@ -62,7 +62,6 @@ namespace Caliburn.Micro.Xamarin.Forms
 
             RootNavigationPage = CreateApplicationPage();
             PrepareViewFirst(RootNavigationPage);
-            MainPage = RootNavigationPage;
         }
 
         /// <summary>
@@ -88,6 +87,8 @@ namespace Caliburn.Micro.Xamarin.Forms
             var navigationService = IoC.Get<INavigationService>();
 
             navigationService.NavigateToViewAsync(viewType);
+
+            MainPage = RootNavigationPage;
         }
 
         /// <summary>


### PR DESCRIPTION
The Exception occurs when the iOS app launches. It is due to `NavigationPage` being rendered before the root view has been set. Android applications are not affected since the root page check occurs in platform-specific code.

Exception details are:

> NavigationPage must have a root Page before being used. Either call PushAsync with a valid Page, or pass a Page to the constructor before usage. (System.InvalidOperationException)
  at Xamarin.Forms.Platform.iOS.NavigationRenderer.ViewDidLoad () <0x10115fc60 + 0x0071c> in <bc5a3d4303744676b3b36f4254bb697d#fcf3a1c8209da1af9ec91eac76a1af7b>:0
  at (wrapper managed-to-native) ObjCRuntime.Messaging:objc_msgSendSuper (intptr,intptr)
  at UIKit.UIViewController.get_View () <0x100a62790 + 0x00073> in <e0596b82250c450abdf075bc558add28#fcf3a1c8209da1af9ec91eac76a1af7b>:0
  at Xamarin.Forms.Platform.iOS.NavigationRenderer.get_NativeView () <0x10115ef90 + 0x0001b> in <bc5a3d4303744676b3b36f4254bb697d#fcf3a1c8209da1af9ec91eac76a1af7b>:0
  at Xamarin.Forms.Platform.iOS.NavigationRenderer.SetElement (Xamarin.Forms.VisualElement element) <0x10115efc0 + 0x000bb> in <bc5a3d4303744676b3b36f4254bb697d#fcf3a1c8209da1af9ec91eac76a1af7b>:0
  at Xamarin.Forms.Platform.iOS.Platform.CreateRen<\M-b\M^@\M-&>

For iOS, you must wait to set the application's `MainPage` property until after the `NavigationPage`'s root view has been set (which is handled by the call to `navigationService.NavigateToViewAsync()`).
