### PR TITLE
partial ShellView-class added

### DIFF
--- a/nuget/start/content/net40/ShellView.xaml.cs.pp
+++ b/nuget/start/content/net40/ShellView.xaml.cs.pp
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace $rootnamespace$
+{
+    /// <summary>
+    /// Interaction logic for ShellView.xaml
+    /// </summary>
+    public partial class ShellView : Window
+    {
+        public ShellView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/nuget/start/content/net45/ShellView.xaml.cs.pp
+++ b/nuget/start/content/net45/ShellView.xaml.cs.pp
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace $rootnamespace$
+{
+    /// <summary>
+    /// Interaction logic for ShellView.xaml
+    /// </summary>
+    public partial class ShellView : Window
+    {
+        public ShellView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
This is a stab at [Issue 529](https://github.com/Caliburn-Micro/Caliburn.Micro/issues/529).
My attempt is inspired by the default VS itemtemplate for windows. 
- added partial class to .NET 4.0 package
- added partial class to .NET 4.5 package

I did not add a partial class to the Silverlight UserControl because I am unsure how those work..
