### PR TITLE
Allow KeyTrigger to match Alt+Key combinations

### DIFF
--- a/samples/scenarios/Scenario.KeyBinding/Input/KeyTrigger.cs
+++ b/samples/scenarios/Scenario.KeyBinding/Input/KeyTrigger.cs
@@ -41,7 +41,8 @@ namespace Scenario.KeyBinding.Input
 
         private void OnAssociatedObjectKeyDown(object sender, KeyEventArgs e)
         {
-            if ((e.Key == Key) && (Keyboard.Modifiers == GetActualModifiers(e.Key, Modifiers)))
+            var key = (e.Key == Key.System) ? e.SystemKey : e.Key;
+            if ((key == Key) && (Keyboard.Modifiers == GetActualModifiers(e.Key, Modifiers)))
             {
                 InvokeActions(e);
             }

--- a/samples/scenarios/Scenario.KeyBinding/ViewModels/ShellViewModel.cs
+++ b/samples/scenarios/Scenario.KeyBinding/ViewModels/ShellViewModel.cs
@@ -31,5 +31,10 @@ namespace Scenario.KeyBinding.ViewModels
         {
             EnterMessage = "Ctrl+Enter has been pressed";
         }
+
+        public void AltEnterPressed()
+        {
+            EnterMessage = "Alt+Enter has been pressed";
+        }
     }
 }

--- a/samples/scenarios/Scenario.KeyBinding/Views/ShellView.xaml
+++ b/samples/scenarios/Scenario.KeyBinding/Views/ShellView.xaml
@@ -15,7 +15,7 @@
         <TextBlock />
         <TextBox HorizontalAlignment="Left"
              Width="278"
-             cal:Message.Attach="[Key Enter] = [EnterPressed]; [Gesture Ctrl+Enter] = [CtrlEnterPressed]">
+             cal:Message.Attach="[Key Enter] = [EnterPressed]; [Gesture Ctrl+Enter] = [CtrlEnterPressed]; [Gesture Alt+Enter] = [AltEnterPressed]">
         </TextBox>
         <TextBlock />
         <TextBlock x:Name="EnterMessage"


### PR DESCRIPTION
KeyTrigger class in KeyBinding sample could not match Alt-key combinations because the actual key code gets pushed into the SystemKey field.  Fixed KeyTrigger and added to sample to test it.