### PR TITLE
Rename methods with "Aysnc" to "Async"

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/NavigationPageAdapter.cs
@@ -105,7 +105,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task GoBackAsync(bool animated = true) {
 
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -120,7 +120,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task GoBackToRootAsync(bool animated = true) 
         {
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -137,7 +137,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewModelAsync(Type viewModelType, object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -156,7 +156,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewModelAsync<T>(object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -173,7 +173,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewAsync(Type viewType, object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -192,7 +192,7 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewAsync<T>(object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAysnc();
+            var canClose = await CanCloseAsync();
 
             if (!canClose)
                 return;
@@ -278,7 +278,7 @@
             }
         }
 
-        private async Task<bool> CanCloseAysnc() {
+        private async Task<bool> CanCloseAsync() {
             var view = navigationPage.CurrentPage;
 
             if (view?.BindingContext is IGuardClose guard)

--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/WindowManager.cs
@@ -177,7 +177,7 @@ namespace Caliburn.Micro
 
             var conductor = new WindowConductor(rootModel, view);
 
-            await conductor.InitialiseAysnc();
+            await conductor.InitialiseAsync();
 
             return view;
         }
@@ -332,7 +332,7 @@ namespace Caliburn.Micro
                 this.view = view;
             }
 
-            public async Task InitialiseAysnc()
+            public async Task InitialiseAsync()
             {
                 if (model is IActivate activator)
                 {

--- a/src/Caliburn.Micro.Platform/Platforms/net46/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46/WindowManager.cs
@@ -177,7 +177,7 @@ namespace Caliburn.Micro
 
             var conductor = new WindowConductor(rootModel, view);
 
-            await conductor.InitialiseAysnc();
+            await conductor.InitialiseAsync();
 
             return view;
         }
@@ -332,7 +332,7 @@ namespace Caliburn.Micro
                 this.view = view;
             }
 
-            public async Task InitialiseAysnc()
+            public async Task InitialiseAsync()
             {
                 if (model is IActivate activator)
                 {


### PR DESCRIPTION
There are two typos where a method suffix is "Aysnc" instead of "Async":
- The private method CanCloseAysnc of NavigationPageAdapter.
- The public method InitialiseAysnc of private class WindowConductor.