### PR TITLE
Use short-circuit AND operator in EventAggregator

### DIFF
--- a/src/Caliburn.Micro.Core/EventAggregator.cs
+++ b/src/Caliburn.Micro.Core/EventAggregator.cs
@@ -17,7 +17,7 @@ namespace Caliburn.Micro
         {
             lock (_handlers)
             {
-                return _handlers.Any(handler => handler.Handles(messageType) & !handler.IsDead);
+                return _handlers.Any(handler => handler.Handles(messageType) && !handler.IsDead);
             }
         }
 


### PR DESCRIPTION
The HandlerExistsFor() method in EventAggregator uses the logical AND
operator & instead of the conditional logical AND operator &&.