### PR TITLE
Updated core csproj file to make MSbuild generate the resource class …

### DIFF
--- a/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
+++ b/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
@@ -19,6 +19,10 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid'))">
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
+  
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid'))">
+    <AndroidResgenNamespace>Caliburn.Micro.Core</AndroidResgenNamespace>
+  </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
     <Reference Include="System.Runtime.Serialization" />


### PR DESCRIPTION
Fixes #669 by generating the Resource class in a different namespace for Caliburn.Micro.Core, it is not at perfect solution but there where no easy way to turn off the autogeneration of the Resource class.

In this way the two Resource classes will be in different namespaces however the one in the new namespace could still be referenced by mistake. 

Basically there is a Caliburn.Micro.Resource and a Caliburn.Micro.Core.Resource class.