### PR TITLE
added default CancellationTokens to common methods (fixes #663)

### DIFF
--- a/src/Caliburn.Micro.Core/Conductor.cs
+++ b/src/Caliburn.Micro.Core/Conductor.cs
@@ -10,7 +10,7 @@ namespace Caliburn.Micro
     public partial class Conductor<T> : ConductorBaseWithActiveItem<T> where T : class
     {
         /// <inheritdoc />
-        public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken)
+        public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken = default)
         {
             if (item != null && item.Equals(ActiveItem))
             {
@@ -41,7 +41,7 @@ namespace Caliburn.Micro
         /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken)
+        public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken = default)
         {
             if (item == null || !item.Equals(ActiveItem))
             {
@@ -61,7 +61,7 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken)
+        public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken = default )
         {
             var closeResult = await CloseStrategy.ExecuteAsync(new[] { ActiveItem }, cancellationToken);
 

--- a/src/Caliburn.Micro.Core/ConductorBase.cs
+++ b/src/Caliburn.Micro.Core/ConductorBase.cs
@@ -56,7 +56,7 @@ namespace Caliburn.Micro
         /// <param name="item">The item to activate.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public abstract Task ActivateItemAsync(T item, CancellationToken cancellationToken);
+        public abstract Task ActivateItemAsync(T item, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deactivates the specified item.
@@ -65,7 +65,7 @@ namespace Caliburn.Micro
         /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public abstract Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken);
+        public abstract Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Called by a subclass when an activation needs processing.

--- a/src/Caliburn.Micro.Core/ConductorWithCollectionAllActive.cs
+++ b/src/Caliburn.Micro.Core/ConductorWithCollectionAllActive.cs
@@ -94,7 +94,7 @@ namespace Caliburn.Micro
                 /// </summary>
                 /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken)
+                public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken = default)
                 {
                     var closeResult = await CloseStrategy.ExecuteAsync(_items.ToList(), cancellationToken);
 
@@ -130,7 +130,7 @@ namespace Caliburn.Micro
                 /// <param name="item">The item to activate.</param>
                 /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken)
+                public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken = default)
                 {
                     if (item == null)
                         return;
@@ -150,7 +150,7 @@ namespace Caliburn.Micro
                 /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
                 /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken)
+                public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken = default)
                 {
                     if (item == null)
                         return;
@@ -175,7 +175,7 @@ namespace Caliburn.Micro
                     return _items;
                 }
 
-                private async Task CloseItemCoreAsync(T item, CancellationToken cancellationToken)
+                private async Task CloseItemCoreAsync(T item, CancellationToken cancellationToken = default)
                 {
                     await ScreenExtensions.TryDeactivateAsync(item, true, cancellationToken);
                     _items.Remove(item);

--- a/src/Caliburn.Micro.Core/ConductorWithCollectionOneActive.cs
+++ b/src/Caliburn.Micro.Core/ConductorWithCollectionOneActive.cs
@@ -63,7 +63,7 @@ namespace Caliburn.Micro
                 /// <param name="item">The item to activate.</param>
                 /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken)
+                public override async Task ActivateItemAsync(T item, CancellationToken cancellationToken = default)
                 {
                     if (item != null && item.Equals(ActiveItem))
                     {
@@ -86,7 +86,7 @@ namespace Caliburn.Micro
                 /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
                 /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken)
+                public override async Task DeactivateItemAsync(T item, bool close, CancellationToken cancellationToken = default)
                 {
                     if (item == null)
                         return;
@@ -102,7 +102,7 @@ namespace Caliburn.Micro
                     }
                 }
 
-                private async Task CloseItemCoreAsync(T item, CancellationToken cancellationToken)
+                private async Task CloseItemCoreAsync(T item, CancellationToken cancellationToken = default)
                 {
                     if (item.Equals(ActiveItem))
                     {
@@ -144,7 +144,7 @@ namespace Caliburn.Micro
                 /// </summary>
                 /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
                 /// <returns>A task that represents the asynchronous operation.</returns>
-                public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken)
+                public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken = default)
                 {
                     var closeResult = await CloseStrategy.ExecuteAsync(_items.ToList(), cancellationToken);
 

--- a/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
+++ b/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
@@ -22,7 +22,7 @@ namespace Caliburn.Micro
         }
 
         /// <inheritdoc />
-        public async Task<ICloseResult<T>> ExecuteAsync(IEnumerable<T> toClose, CancellationToken cancellationToken)
+        public async Task<ICloseResult<T>> ExecuteAsync(IEnumerable<T> toClose, CancellationToken cancellationToken = default)
         {
             var closeable = new List<T>();
             var closeCanOccur = true;

--- a/src/Caliburn.Micro.Core/EventAggregator.cs
+++ b/src/Caliburn.Micro.Core/EventAggregator.cs
@@ -65,7 +65,7 @@ namespace Caliburn.Micro
         }
 
         /// <inheritdoc />
-        public virtual Task PublishAsync(object message, Func<Func<Task>, Task> marshal, CancellationToken cancellationToken)
+        public virtual Task PublishAsync(object message, Func<Func<Task>, Task> marshal, CancellationToken cancellationToken = default)
         {
             if (message == null)
             {

--- a/src/Caliburn.Micro.Core/IActivate.cs
+++ b/src/Caliburn.Micro.Core/IActivate.cs
@@ -19,7 +19,7 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        Task ActivateAsync(CancellationToken cancellationToken);
+        Task ActivateAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Raised after activation occurs.

--- a/src/Caliburn.Micro.Core/ICloseStrategy.cs
+++ b/src/Caliburn.Micro.Core/ICloseStrategy.cs
@@ -17,6 +17,6 @@ namespace Caliburn.Micro
         /// <param name="toClose">Items that are requesting close.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation and contains the result of the strategy.</returns>
-        Task<ICloseResult<T>> ExecuteAsync(IEnumerable<T> toClose, CancellationToken cancellationToken);
+        Task<ICloseResult<T>> ExecuteAsync(IEnumerable<T> toClose, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Caliburn.Micro.Core/IConductor.cs
+++ b/src/Caliburn.Micro.Core/IConductor.cs
@@ -15,7 +15,7 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="item">The item to activate.</param>
          /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        Task ActivateItemAsync(object item, CancellationToken cancellationToken);
+        Task ActivateItemAsync(object item, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deactivates the specified item.
@@ -24,7 +24,7 @@ namespace Caliburn.Micro
         /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        Task DeactivateItemAsync(object item, bool close, CancellationToken cancellationToken);
+        Task DeactivateItemAsync(object item, bool close, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Occurs when an activation request is processed.

--- a/src/Caliburn.Micro.Core/IDeactivate.cs
+++ b/src/Caliburn.Micro.Core/IDeactivate.cs
@@ -20,7 +20,7 @@ namespace Caliburn.Micro
         /// <param name="close">Indicates whether or not this instance is being closed.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        Task DeactivateAsync(bool close, CancellationToken cancellationToken);
+        Task DeactivateAsync(bool close, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Raised after deactivation.

--- a/src/Caliburn.Micro.Core/IEventAggregator.cs
+++ b/src/Caliburn.Micro.Core/IEventAggregator.cs
@@ -37,6 +37,6 @@ namespace Caliburn.Micro
         /// <param name = "marshal">Allows the publisher to provide a custom thread marshaller for the message publication.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        Task PublishAsync(object message, Func<Func<Task>, Task> marshal, CancellationToken cancellationToken);
+        Task PublishAsync(object message, Func<Func<Task>, Task> marshal, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Caliburn.Micro.Core/IGuardClose.cs
+++ b/src/Caliburn.Micro.Core/IGuardClose.cs
@@ -13,6 +13,6 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation and contains the result of the close.</returns>
-        Task<bool> CanCloseAsync(CancellationToken cancellationToken);
+        Task<bool> CanCloseAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Caliburn.Micro.Core/Screen.cs
+++ b/src/Caliburn.Micro.Core/Screen.cs
@@ -147,7 +147,7 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation and holds the value of the close check..</returns>
-        public virtual Task<bool> CanCloseAsync(CancellationToken cancellationToken)
+        public virtual Task<bool> CanCloseAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }

--- a/src/Caliburn.Micro.Core/ScreenExtensions.cs
+++ b/src/Caliburn.Micro.Core/ScreenExtensions.cs
@@ -34,6 +34,17 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="potentialDeactivatable">The potential deactivatable.</param>
         /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public static Task TryDeactivateAsync(object potentialDeactivatable, bool close)
+        {
+            return potentialDeactivatable is IDeactivate deactivator ? deactivator.DeactivateAsync(close, CancellationToken.None) : Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Deactivates the item if it implements <see cref="IDeactivate"/>, otherwise does nothing.
+        /// </summary>
+        /// <param name="potentialDeactivatable">The potential deactivatable.</param>
+        /// <param name="close">Indicates whether or not to close the item after deactivating it.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         public static Task TryDeactivateAsync(object potentialDeactivatable, bool close, CancellationToken cancellationToken)
@@ -46,11 +57,33 @@ namespace Caliburn.Micro
         /// </summary>
         /// <param name="conductor">The conductor.</param>
         /// <param name="item">The item to close.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public static Task CloseItemAsync(this IConductor conductor, object item)
+        {
+            return conductor.DeactivateItemAsync(item, true, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Closes the specified item.
+        /// </summary>
+        /// <param name="conductor">The conductor.</param>
+        /// <param name="item">The item to close.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         public static Task CloseItemAsync(this IConductor conductor, object item, CancellationToken cancellationToken)
         {
             return conductor.DeactivateItemAsync(item, true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Closes the specified item.
+        /// </summary>
+        /// <param name="conductor">The conductor.</param>
+        /// <param name="item">The item to close.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public static Task CloseItemAsync<T>(this ConductorBase<T> conductor, T item) where T : class
+        {
+            return conductor.DeactivateItemAsync(item, true, CancellationToken.None);
         }
 
         /// <summary>


### PR DESCRIPTION
This adds default CancellationTokens to many common methods that are likely to be called by the user of this library (I did not add it to the event like methods like OnInitalized).
This fixes #663 
Since for some mehtods there was already a overload without a CancellationToken I tried to be consistent inside a class. That means if the class already conatined such overloads for some methods I did add overloads without CancellationToken for the remaining ones in this class, otherwise I provided a default value for the existing declarations.