### PR TITLE
Fixed #682 - AssemblySource throws ArgumentExceptions

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
@@ -88,7 +88,7 @@ namespace Caliburn.Micro
             {
                 try
                 {
-                    //if (!AssemblySource.Instance.Contains(assembly))
+                    if (!AssemblySource.Instance.Contains(assembly))
                         AssemblySource.Instance.Add(assembly);
                 }
                 catch (ArgumentException)
@@ -114,7 +114,7 @@ namespace Caliburn.Micro
             {
                 try
                 {
-                    //if (!AssemblySource.Instance.Contains(assembly))
+                    if (!AssemblySource.Instance.Contains(assembly))
                         AssemblySource.Instance.Add(assembly);
                 }
                 catch (ArgumentException)

--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
@@ -88,7 +88,7 @@ namespace Caliburn.Micro
             {
                 try
                 {
-                    if (!AssemblySource.Instance.Contains(assembly))
+                    //if (!AssemblySource.Instance.Contains(assembly))
                         AssemblySource.Instance.Add(assembly);
                 }
                 catch (ArgumentException)
@@ -114,7 +114,7 @@ namespace Caliburn.Micro
             {
                 try
                 {
-                    if (!AssemblySource.Instance.Contains(assembly))
+                    //if (!AssemblySource.Instance.Contains(assembly))
                         AssemblySource.Instance.Add(assembly);
                 }
                 catch (ArgumentException)

--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
@@ -83,7 +83,19 @@ namespace Caliburn.Micro
         protected virtual void StartDesignTime()
         {
             AssemblySource.Instance.Clear();
-            AssemblySource.Instance.AddRange(SelectAssemblies());
+			
+			foreach (var assembly in SelectAssemblies())
+            {
+                try
+                {
+                    if (!AssemblySource.Instance.Contains(assembly))
+                        AssemblySource.Instance.Add(assembly);
+                }
+                catch (ArgumentException)
+                {
+                    // ignore
+                }
+            }
 
             Configure();
             IoC.GetInstance = GetInstance;
@@ -97,7 +109,19 @@ namespace Caliburn.Micro
         protected virtual void StartRuntime()
         {
             AssemblySourceCache.Install();
-            AssemblySource.Instance.AddRange(SelectAssemblies());
+			
+			foreach (var assembly in SelectAssemblies())
+            {
+                try
+                {
+                    if (!AssemblySource.Instance.Contains(assembly))
+                        AssemblySource.Instance.Add(assembly);
+                }
+                catch (ArgumentException)
+                {
+                    // ignore
+                }
+            }
 
             if (useApplication)
             {


### PR DESCRIPTION
... for duplicate keys. This catches the ArgumentExeption and continues instead of breaking. Also includes the DesignTime part, even though this never occurred there but keeps code the same style in both methods.