### PR TITLE
Strong-name all Assemblies

### DIFF
--- a/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
+++ b/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
@@ -5,9 +5,6 @@
     <PackageId>Caliburn.Micro.Core</PackageId>
     <Product>Caliburn.Micro Core</Product>
     <RootNamespace>Caliburn.Micro</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <AssemblyOriginatorKeyFile>.\..\Caliburn.Micro.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -19,7 +16,7 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
-  
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <AndroidResgenNamespace>Caliburn.Micro.Core</AndroidResgenNamespace>
   </PropertyGroup>

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -5,15 +5,12 @@
     <PackageId>Caliburn.Micro</PackageId>
     <Product>Caliburn.Micro</Product>
     <RootNamespace>Caliburn.Micro</RootNamespace>
+    <AssemblyOriginatorKeyFile>.\..\Caliburn.Micro.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'Xamarin.iOS10' or '$(TargetFramework)' == 'MonoAndroid80'">
     <DefineConstants>XFORMS</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
-    <AssemblyOriginatorKeyFile>.\..\Caliburn.Micro.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Possible solution to #700
Tweaks for consistent strong-naming.
Also, reduced the number of targets required.