### PR TITLE
Fixes the parsing of negative numbers in action parameters #521

### DIFF
--- a/src/Caliburn.Micro.Platform.Tests/ParserTests.cs
+++ b/src/Caliburn.Micro.Platform.Tests/ParserTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Caliburn.Micro.Platform.Tests
+{
+    public class ParserTests
+    {
+        [Fact]
+        public void CreateParametersWithOddNumbers()
+        {
+            var evenResult = Parser.CreateParameter(null, "0.1");
+            var oddResult = Parser.CreateParameter(null, "-0.1");
+            var nanResult = Parser.CreateParameter(null, "-0.1abc");
+
+            Assert.Equal(0.1, double.Parse((string)evenResult.Value));
+            Assert.Equal(-0.1, double.Parse((string)oddResult.Value));
+            Assert.Null(nanResult.Value);
+        }
+    }
+}

--- a/src/Caliburn.Micro.Platform/Parser.cs
+++ b/src/Caliburn.Micro.Platform/Parser.cs
@@ -262,7 +262,7 @@
             {
                 actualParameter.Value = parameterText.Substring(1, parameterText.Length - 2);
             }
-            else if (MessageBinder.SpecialValues.ContainsKey(parameterText.ToLower()) || char.IsNumber(parameterText[0]))
+            else if (MessageBinder.SpecialValues.ContainsKey(parameterText.ToLower()) || decimal.TryParse(parameterText, out _))
             {
                 actualParameter.Value = parameterText;
             }


### PR DESCRIPTION
Fixes #521 

Changes the char.IsNumber to decimal.TryParse as the try parse will take the sign into account. 