### PR TITLE
Parameter was not made aware of owner because of assignment order #517

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
@@ -39,6 +39,10 @@
         public ActionMessage()
         {
             Parameters = new AttachedCollection<Parameter>();
+            Parameters.CollectionChanged += (s, e) =>
+            {
+                e.NewItems.OfType<Parameter>().Apply(x => x.MakeAwareOf(this));
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
When the OnAttached event was fired the Parameters had not yet been added to the parameters collection and was never made aware of the owning ActionMessage. A CollectionChanged EventHandler on the parameters collection is used to call MakeAwareOf.

Fixes #517