### PR TITLE
Fix bug that causes children to close when parent cannot close

### DIFF
--- a/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
+++ b/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
@@ -46,6 +46,11 @@ namespace Caliburn.Micro
                 }
             }
 
+            if (!this.closeConductedItemsWhenConductorCannotClose)
+            {
+                closeable.Clear();
+            }
+
             return new CloseResult<T>(closeCanOccur, closeable);
         }
     }

--- a/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
+++ b/src/Caliburn.Micro.Core/DefaultCloseStrategy.cs
@@ -46,7 +46,7 @@ namespace Caliburn.Micro
                 }
             }
 
-            if (!this.closeConductedItemsWhenConductorCannotClose)
+            if (!this.closeConductedItemsWhenConductorCannotClose && !closeCanOccur)
             {
                 closeable.Clear();
             }


### PR DESCRIPTION
When the conductor cannot close, the default of the DefaultCloseStrategy should not close the conducted items.

This PR fixes this issue