### PR TITLE
Action message select overloaded function #314

### DIFF
--- a/src/Caliburn.Micro.Platform.Tests/ActionMessageTests.cs
+++ b/src/Caliburn.Micro.Platform.Tests/ActionMessageTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -10,22 +12,293 @@ namespace Caliburn.Micro.Platform.Tests
 {
     public class ActionMessageTests
     {
-
         [Fact]
-        public void GetMethodPicksOverLoad()
+        public void GetMethodPicksOverLoadStructParameter()
         {
+            //Arrange
             var am = new ActionMessage();
             am.MethodName = "Overloaded";
-            am.Parameters.Add(new Parameter(){ Value = "2"});
-            var obj = new Overloads(); 
 
+            am.Parameters.Add(new Parameter() { Value = 1 });
+            am.Parameters.Add(new Parameter() { Value = 1 });
+            var obj = new Overloads();
 
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(1, 1));
+
+            //Act
             var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadStructStringParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = 1 });
+            am.Parameters.Add(new Parameter() { Value = 1 });
+            am.Parameters.Add(new Parameter() { Value = "" });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(1, 1, ""));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadStringParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = "" });
+            am.Parameters.Add(new Parameter() { Value = "" });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded("", ""));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadStringStructParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = "" });
+            am.Parameters.Add(new Parameter() { Value = "" });
+            am.Parameters.Add(new Parameter() { Value = 1 });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded("", "", 1));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadTwoDifferntParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Foo() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(new Foo(), new Bar()));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadTwoBaseParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Foo() });
+            am.Parameters.Add(new Parameter() { Value = new Foo() });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(new Foo(), new Foo()));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadTwoDerivedParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(new Bar(), new Bar()));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadEnumParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = OverloadEnum.One });
+            var obj = new Overloads();
+
+            var expected = MethodInfoHelper.GetMethodInfo<Overloads>(o => o.Overloaded(OverloadEnum.One));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadDerivedOnlyParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new OverloadsDerivedOnly();
+
+            var expected = MethodInfoHelper.GetMethodInfo<OverloadsDerivedOnly>(o => o.Overloaded(new Bar(), new Bar()));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadDerivedOnlyBaseParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Foo() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new OverloadsDerivedOnly();
+
+            MethodInfo expected = null;
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+
+        [Fact]
+        public void GetMethodPicksOverLoadBaseOnlyParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new OverloadsBaseOnly();
+
+            var expected = MethodInfoHelper.GetMethodInfo<OverloadsBaseOnly>(o => o.Overloaded(new Foo(), new Foo()));
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void GetMethodPicksOverLoadBaseOnlyBaseParameter()
+        {
+            //Arrange
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+
+            am.Parameters.Add(new Parameter() { Value = new Foo() });
+            am.Parameters.Add(new Parameter() { Value = new Bar() });
+            var obj = new OverloadsBaseOnly();
+
+            MethodInfo expected =  MethodInfoHelper.GetMethodInfo<OverloadsBaseOnly>(o => o.Overloaded(new Foo(), new Foo()));
+            ;
+
+            //Act
+            var result = ActionMessage.GetTargetMethod(am, obj);
+
+            //Assert
+            Assert.Equal(result, expected);
+        }
+
+        enum OverloadEnum
+        {
+            One,Two,Three
+        }
+
+        class OverloadsBaseOnly
+        {
+            public void Overloaded(Foo f)
+            {
+
+            }
+
+            public void Overloaded(Foo f, Foo f2)
+            {
+
+            }
+        }
+
+        class OverloadsDerivedOnly
+        {
+            public void Overloaded(Bar b)
+            {
+
+            }
+
+            public void Overloaded(Bar b, Bar b2)
+            {
+
+            }
         }
 
         class Overloads
         {
-            public void Overloaded(int s)
+            public void Overloaded(int i)
+            {
+
+            }
+
+            public void Overloaded(int i, int i2)
+            {
+
+            }
+
+            public void Overloaded(int i, int i2, string s)
             {
 
             }
@@ -35,12 +308,47 @@ namespace Caliburn.Micro.Platform.Tests
 
             }
 
-            public void Overloaded(Bar s)
+            public void Overloaded(string s, string s2)
             {
 
             }
 
-            public void Overloaded(Foo s)
+            public void Overloaded(string s, string s2, int i)
+            {
+
+            }
+
+            public void Overloaded(Foo F)
+            {
+
+            }
+
+            public void Overloaded(Bar B)
+            {
+
+            }
+
+            public void Overloaded(OverloadEnum E)
+            {
+
+            }
+
+            public void Overloaded(Foo s, Foo f)
+            {
+
+            }
+
+            public void Overloaded(Foo s, Bar b)
+            {
+
+            }
+
+            public void Overloaded(Bar s, Bar b)
+            {
+
+            }
+
+            public void Overloaded(Bar s, Foo f)
             {
 
             }
@@ -55,5 +363,19 @@ namespace Caliburn.Micro.Platform.Tests
         {
 
         }
+    }
+
+    public static class MethodInfoHelper
+    {
+        public static MethodInfo GetMethodInfo<T>(Expression<Action<T>> expression)
+        {
+            var member = expression.Body as MethodCallExpression;
+
+            if (member != null)
+                return member.Method;
+
+            throw new ArgumentException("Expression is not a method", "expression");
+        }
+
     }
 }

--- a/src/Caliburn.Micro.Platform.Tests/ActionMessageTests.cs
+++ b/src/Caliburn.Micro.Platform.Tests/ActionMessageTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Xunit;
+
+namespace Caliburn.Micro.Platform.Tests
+{
+    public class ActionMessageTests
+    {
+
+        [Fact]
+        public void GetMethodPicksOverLoad()
+        {
+            var am = new ActionMessage();
+            am.MethodName = "Overloaded";
+            am.Parameters.Add(new Parameter(){ Value = "2"});
+            var obj = new Overloads(); 
+
+
+            var result = ActionMessage.GetTargetMethod(am, obj);
+        }
+
+        class Overloads
+        {
+            public void Overloaded(int s)
+            {
+
+            }
+
+            public void Overloaded(string s)
+            {
+
+            }
+
+            public void Overloaded(Bar s)
+            {
+
+            }
+
+            public void Overloaded(Foo s)
+            {
+
+            }
+        }
+
+        class Foo
+        {
+
+        }
+
+        class Bar : Foo
+        {
+
+        }
+    }
+}

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
@@ -313,31 +313,7 @@
         /// <returns>The matching method, if available.</returns>
         public static Func<ActionMessage, object, MethodInfo> GetTargetMethod = (message, target) =>
         {
-            //return (from method in target.GetType().GetRuntimeMethods()
-            //        where method.Name == message.MethodName
-            //        let methodParameters = method.GetParameters()
-            //        where message.Parameters.Count == methodParameters.Length
-            //        select method).FirstOrDefault();
-            var methods = (from method in target.GetType().GetRuntimeMethods()
-                           where method.Name == message.MethodName
-                           let methodParameters = method.GetParameters()
-                           where message.Parameters.Count == methodParameters.Length && message.Parameters.OfType<Parameter>().Zip(methodParameters,
-                                     (parameter, info) => info.ParameterType.IsInstanceOfType(parameter.Value)).All(b => b)
-                           select method);
-
-            MethodInfo returnMethodInfo = null;
-            foreach (MethodInfo method in methods)
-            {
-                returnMethodInfo = method;
-                if (method.GetParameters().Zip(message.Parameters.OfType<Parameter>(), (info, parameter) =>
-                    parameter.Value.GetType().IsAssignableFrom(info.ParameterType)
-                ).All(b => b))
-                {
-                    break;
-                }
-            }
-
-            return returnMethodInfo;
+            return GetMethodInfo(target.GetType(), message.MethodName, message);
         };
 
         /// <summary>
@@ -463,7 +439,7 @@
             MethodInfo guard = null;
             foreach (string possibleGuardName in possibleGuardNames)
             {
-                guard = GetMethodInfo(targetType, possibleGuardName);
+                guard = GetMethodInfo(targetType, possibleGuardName, context.Message);
                 if (guard != null) break;
             }
 
@@ -514,6 +490,31 @@
 
         static MethodInfo GetMethodInfo(Type t, string methodName) {
             return t.GetRuntimeMethods().SingleOrDefault(m => m.Name == methodName);
+        }
+
+        static MethodInfo GetMethodInfo(Type t, string methodName, ActionMessage message)
+        {
+            var methods = (from method in t.GetRuntimeMethods()
+                where method.Name == methodName
+                let methodParameters = method.GetParameters()
+                where message.Parameters.Count == methodParameters.Length
+                      && message.Parameters.OfType<Parameter>().Zip(methodParameters,
+                          (parameter, info) => info.ParameterType.IsInstanceOfType(parameter.Value)).All(b => b)
+                select method);
+
+            MethodInfo returnMethodInfo = null;
+            foreach (MethodInfo method in methods)
+            {
+                returnMethodInfo = method;
+                if (method.GetParameters().Zip(message.Parameters.OfType<Parameter>(), (info, parameter) =>
+                    parameter.Value.GetType().IsAssignableFrom(info.ParameterType)
+                ).All(b => b))
+                {
+                    break;
+                }
+            }
+
+            return returnMethodInfo;
         }
     }
 }

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/ActionMessage.cs
@@ -313,11 +313,31 @@
         /// <returns>The matching method, if available.</returns>
         public static Func<ActionMessage, object, MethodInfo> GetTargetMethod = (message, target) =>
         {
-            return (from method in target.GetType().GetRuntimeMethods()
-                    where method.Name == message.MethodName
-                    let methodParameters = method.GetParameters()
-                    where message.Parameters.Count == methodParameters.Length
-                    select method).FirstOrDefault();
+            //return (from method in target.GetType().GetRuntimeMethods()
+            //        where method.Name == message.MethodName
+            //        let methodParameters = method.GetParameters()
+            //        where message.Parameters.Count == methodParameters.Length
+            //        select method).FirstOrDefault();
+            var methods = (from method in target.GetType().GetRuntimeMethods()
+                           where method.Name == message.MethodName
+                           let methodParameters = method.GetParameters()
+                           where message.Parameters.Count == methodParameters.Length && message.Parameters.OfType<Parameter>().Zip(methodParameters,
+                                     (parameter, info) => info.ParameterType.IsInstanceOfType(parameter.Value)).All(b => b)
+                           select method);
+
+            MethodInfo returnMethodInfo = null;
+            foreach (MethodInfo method in methods)
+            {
+                returnMethodInfo = method;
+                if (method.GetParameters().Zip(message.Parameters.OfType<Parameter>(), (info, parameter) =>
+                    parameter.Value.GetType().IsAssignableFrom(info.ParameterType)
+                ).All(b => b))
+                {
+                    break;
+                }
+            }
+
+            return returnMethodInfo;
         };
 
         /// <summary>


### PR DESCRIPTION
This is a proposal on how to fix #314, the implementation in this pull request is more strict than Caliburn.Micro has been in the past.

If there is no method found that matches the parameter types supplied it will return null. This means that a string wont be converted to int even if it is possible. It will take into account derived classes.

I would love some feedback on this @vb2ae, @nigel-sampson.  