### PR TITLE
Issue749/navigation page updates

### DIFF
--- a/samples/features/Features.Forms/Features.Forms.Android/Application.cs
+++ b/samples/features/Features.Forms/Features.Forms.Android/Application.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Caliburn.Micro;
+using Features.CrossPlatform;
+
+namespace Features.Forms.Droid
+{
+    [Application]
+    public class Application : CaliburnApplication
+    {
+        private SimpleContainer container;
+
+        public Application(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+
+        }
+
+        public override void OnCreate()
+        {
+            base.OnCreate();
+
+            Initialize();
+        }
+
+        protected override void Configure()
+        {
+            container = new SimpleContainer();
+            container.Instance(container);
+            container.Singleton<FormsApp>();
+            container.Singleton<IEventAggregator, EventAggregator>();
+        }
+
+        protected override IEnumerable<Assembly> SelectAssemblies()
+        {
+            return new[]
+            {
+                GetType().Assembly,
+                typeof (FormsApp).Assembly
+            };
+        }
+
+        protected override void BuildUp(object instance)
+        {
+            container.BuildUp(instance);
+        }
+
+        protected override IEnumerable<object> GetAllInstances(Type service)
+        {
+            return container.GetAllInstances(service);
+        }
+
+        protected override object GetInstance(Type service, string key)
+        {
+            return container.GetInstance(service, key);
+        }
+    }
+}

--- a/samples/features/Features.Forms/Features.Forms.Android/Features.Forms.Android.csproj
+++ b/samples/features/Features.Forms/Features.Forms.Android/Features.Forms.Android.csproj
@@ -30,6 +30,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,6 +71,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="25.4.0.2" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Application.cs" />
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/samples/features/Features.Forms/Features.Forms.Android/Resources/Resource.designer.cs
+++ b/samples/features/Features.Forms/Features.Forms.Android/Resources/Resource.designer.cs
@@ -25,10 +25,1111 @@ namespace Features.Forms.Droid
 		
 		public static void UpdateIdValues()
 		{
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarSize = global::Features.Forms.Droid.Resource.Attribute.actionBarSize;
+		}
+		
+		public partial class Animation
+		{
+			
+			// aapt resource value: 0x7F010000
+			public const int abc_fade_in = 2130771968;
+			
+			// aapt resource value: 0x7F010001
+			public const int abc_fade_out = 2130771969;
+			
+			// aapt resource value: 0x7F010002
+			public const int abc_grow_fade_in_from_bottom = 2130771970;
+			
+			// aapt resource value: 0x7F010003
+			public const int abc_popup_enter = 2130771971;
+			
+			// aapt resource value: 0x7F010004
+			public const int abc_popup_exit = 2130771972;
+			
+			// aapt resource value: 0x7F010005
+			public const int abc_shrink_fade_out_from_bottom = 2130771973;
+			
+			// aapt resource value: 0x7F010006
+			public const int abc_slide_in_bottom = 2130771974;
+			
+			// aapt resource value: 0x7F010007
+			public const int abc_slide_in_top = 2130771975;
+			
+			// aapt resource value: 0x7F010008
+			public const int abc_slide_out_bottom = 2130771976;
+			
+			// aapt resource value: 0x7F010009
+			public const int abc_slide_out_top = 2130771977;
+			
+			// aapt resource value: 0x7F01000A
+			public const int design_bottom_sheet_slide_in = 2130771978;
+			
+			// aapt resource value: 0x7F01000B
+			public const int design_bottom_sheet_slide_out = 2130771979;
+			
+			// aapt resource value: 0x7F01000C
+			public const int design_fab_in = 2130771980;
+			
+			// aapt resource value: 0x7F01000D
+			public const int design_fab_out = 2130771981;
+			
+			// aapt resource value: 0x7F01000E
+			public const int design_snackbar_in = 2130771982;
+			
+			// aapt resource value: 0x7F01000F
+			public const int design_snackbar_out = 2130771983;
+			
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animation()
+			{
+			}
+		}
+		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7F020000
+			public const int design_appbar_state_list_animator = 2130837504;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
 		}
 		
 		public partial class Attribute
 		{
+			
+			// aapt resource value: 0x7F030000
+			public const int actionBarDivider = 2130903040;
+			
+			// aapt resource value: 0x7F030001
+			public const int actionBarItemBackground = 2130903041;
+			
+			// aapt resource value: 0x7F030002
+			public const int actionBarPopupTheme = 2130903042;
+			
+			// aapt resource value: 0x7F030003
+			public const int actionBarSize = 2130903043;
+			
+			// aapt resource value: 0x7F030004
+			public const int actionBarSplitStyle = 2130903044;
+			
+			// aapt resource value: 0x7F030005
+			public const int actionBarStyle = 2130903045;
+			
+			// aapt resource value: 0x7F030006
+			public const int actionBarTabBarStyle = 2130903046;
+			
+			// aapt resource value: 0x7F030007
+			public const int actionBarTabStyle = 2130903047;
+			
+			// aapt resource value: 0x7F030008
+			public const int actionBarTabTextStyle = 2130903048;
+			
+			// aapt resource value: 0x7F030009
+			public const int actionBarTheme = 2130903049;
+			
+			// aapt resource value: 0x7F03000A
+			public const int actionBarWidgetTheme = 2130903050;
+			
+			// aapt resource value: 0x7F03000B
+			public const int actionButtonStyle = 2130903051;
+			
+			// aapt resource value: 0x7F03000C
+			public const int actionDropDownStyle = 2130903052;
+			
+			// aapt resource value: 0x7F03000D
+			public const int actionLayout = 2130903053;
+			
+			// aapt resource value: 0x7F03000E
+			public const int actionMenuTextAppearance = 2130903054;
+			
+			// aapt resource value: 0x7F03000F
+			public const int actionMenuTextColor = 2130903055;
+			
+			// aapt resource value: 0x7F030010
+			public const int actionModeBackground = 2130903056;
+			
+			// aapt resource value: 0x7F030011
+			public const int actionModeCloseButtonStyle = 2130903057;
+			
+			// aapt resource value: 0x7F030012
+			public const int actionModeCloseDrawable = 2130903058;
+			
+			// aapt resource value: 0x7F030013
+			public const int actionModeCopyDrawable = 2130903059;
+			
+			// aapt resource value: 0x7F030014
+			public const int actionModeCutDrawable = 2130903060;
+			
+			// aapt resource value: 0x7F030015
+			public const int actionModeFindDrawable = 2130903061;
+			
+			// aapt resource value: 0x7F030016
+			public const int actionModePasteDrawable = 2130903062;
+			
+			// aapt resource value: 0x7F030017
+			public const int actionModePopupWindowStyle = 2130903063;
+			
+			// aapt resource value: 0x7F030018
+			public const int actionModeSelectAllDrawable = 2130903064;
+			
+			// aapt resource value: 0x7F030019
+			public const int actionModeShareDrawable = 2130903065;
+			
+			// aapt resource value: 0x7F03001A
+			public const int actionModeSplitBackground = 2130903066;
+			
+			// aapt resource value: 0x7F03001B
+			public const int actionModeStyle = 2130903067;
+			
+			// aapt resource value: 0x7F03001C
+			public const int actionModeWebSearchDrawable = 2130903068;
+			
+			// aapt resource value: 0x7F03001D
+			public const int actionOverflowButtonStyle = 2130903069;
+			
+			// aapt resource value: 0x7F03001E
+			public const int actionOverflowMenuStyle = 2130903070;
+			
+			// aapt resource value: 0x7F03001F
+			public const int actionProviderClass = 2130903071;
+			
+			// aapt resource value: 0x7F030020
+			public const int actionViewClass = 2130903072;
+			
+			// aapt resource value: 0x7F030021
+			public const int activityChooserViewStyle = 2130903073;
+			
+			// aapt resource value: 0x7F030022
+			public const int alertDialogButtonGroupStyle = 2130903074;
+			
+			// aapt resource value: 0x7F030023
+			public const int alertDialogCenterButtons = 2130903075;
+			
+			// aapt resource value: 0x7F030024
+			public const int alertDialogStyle = 2130903076;
+			
+			// aapt resource value: 0x7F030025
+			public const int alertDialogTheme = 2130903077;
+			
+			// aapt resource value: 0x7F030026
+			public const int allowStacking = 2130903078;
+			
+			// aapt resource value: 0x7F030027
+			public const int alpha = 2130903079;
+			
+			// aapt resource value: 0x7F030028
+			public const int arrowHeadLength = 2130903080;
+			
+			// aapt resource value: 0x7F030029
+			public const int arrowShaftLength = 2130903081;
+			
+			// aapt resource value: 0x7F03002A
+			public const int autoCompleteTextViewStyle = 2130903082;
+			
+			// aapt resource value: 0x7F03002B
+			public const int background = 2130903083;
+			
+			// aapt resource value: 0x7F03002C
+			public const int backgroundSplit = 2130903084;
+			
+			// aapt resource value: 0x7F03002D
+			public const int backgroundStacked = 2130903085;
+			
+			// aapt resource value: 0x7F03002E
+			public const int backgroundTint = 2130903086;
+			
+			// aapt resource value: 0x7F03002F
+			public const int backgroundTintMode = 2130903087;
+			
+			// aapt resource value: 0x7F030030
+			public const int barLength = 2130903088;
+			
+			// aapt resource value: 0x7F030031
+			public const int behavior_autoHide = 2130903089;
+			
+			// aapt resource value: 0x7F030032
+			public const int behavior_hideable = 2130903090;
+			
+			// aapt resource value: 0x7F030033
+			public const int behavior_overlapTop = 2130903091;
+			
+			// aapt resource value: 0x7F030034
+			public const int behavior_peekHeight = 2130903092;
+			
+			// aapt resource value: 0x7F030035
+			public const int behavior_skipCollapsed = 2130903093;
+			
+			// aapt resource value: 0x7F030037
+			public const int borderlessButtonStyle = 2130903095;
+			
+			// aapt resource value: 0x7F030036
+			public const int borderWidth = 2130903094;
+			
+			// aapt resource value: 0x7F030038
+			public const int bottomSheetDialogTheme = 2130903096;
+			
+			// aapt resource value: 0x7F030039
+			public const int bottomSheetStyle = 2130903097;
+			
+			// aapt resource value: 0x7F03003A
+			public const int buttonBarButtonStyle = 2130903098;
+			
+			// aapt resource value: 0x7F03003B
+			public const int buttonBarNegativeButtonStyle = 2130903099;
+			
+			// aapt resource value: 0x7F03003C
+			public const int buttonBarNeutralButtonStyle = 2130903100;
+			
+			// aapt resource value: 0x7F03003D
+			public const int buttonBarPositiveButtonStyle = 2130903101;
+			
+			// aapt resource value: 0x7F03003E
+			public const int buttonBarStyle = 2130903102;
+			
+			// aapt resource value: 0x7F03003F
+			public const int buttonGravity = 2130903103;
+			
+			// aapt resource value: 0x7F030040
+			public const int buttonPanelSideLayout = 2130903104;
+			
+			// aapt resource value: 0x7F030041
+			public const int buttonStyle = 2130903105;
+			
+			// aapt resource value: 0x7F030042
+			public const int buttonStyleSmall = 2130903106;
+			
+			// aapt resource value: 0x7F030043
+			public const int buttonTint = 2130903107;
+			
+			// aapt resource value: 0x7F030044
+			public const int buttonTintMode = 2130903108;
+			
+			// aapt resource value: 0x7F030045
+			public const int cardBackgroundColor = 2130903109;
+			
+			// aapt resource value: 0x7F030046
+			public const int cardCornerRadius = 2130903110;
+			
+			// aapt resource value: 0x7F030047
+			public const int cardElevation = 2130903111;
+			
+			// aapt resource value: 0x7F030048
+			public const int cardMaxElevation = 2130903112;
+			
+			// aapt resource value: 0x7F030049
+			public const int cardPreventCornerOverlap = 2130903113;
+			
+			// aapt resource value: 0x7F03004A
+			public const int cardUseCompatPadding = 2130903114;
+			
+			// aapt resource value: 0x7F03004B
+			public const int checkboxStyle = 2130903115;
+			
+			// aapt resource value: 0x7F03004C
+			public const int checkedTextViewStyle = 2130903116;
+			
+			// aapt resource value: 0x7F03004D
+			public const int closeIcon = 2130903117;
+			
+			// aapt resource value: 0x7F03004E
+			public const int closeItemLayout = 2130903118;
+			
+			// aapt resource value: 0x7F03004F
+			public const int collapseContentDescription = 2130903119;
+			
+			// aapt resource value: 0x7F030051
+			public const int collapsedTitleGravity = 2130903121;
+			
+			// aapt resource value: 0x7F030052
+			public const int collapsedTitleTextAppearance = 2130903122;
+			
+			// aapt resource value: 0x7F030050
+			public const int collapseIcon = 2130903120;
+			
+			// aapt resource value: 0x7F030053
+			public const int color = 2130903123;
+			
+			// aapt resource value: 0x7F030054
+			public const int colorAccent = 2130903124;
+			
+			// aapt resource value: 0x7F030055
+			public const int colorBackgroundFloating = 2130903125;
+			
+			// aapt resource value: 0x7F030056
+			public const int colorButtonNormal = 2130903126;
+			
+			// aapt resource value: 0x7F030057
+			public const int colorControlActivated = 2130903127;
+			
+			// aapt resource value: 0x7F030058
+			public const int colorControlHighlight = 2130903128;
+			
+			// aapt resource value: 0x7F030059
+			public const int colorControlNormal = 2130903129;
+			
+			// aapt resource value: 0x7F03005A
+			public const int colorPrimary = 2130903130;
+			
+			// aapt resource value: 0x7F03005B
+			public const int colorPrimaryDark = 2130903131;
+			
+			// aapt resource value: 0x7F03005C
+			public const int colorSwitchThumbNormal = 2130903132;
+			
+			// aapt resource value: 0x7F03005D
+			public const int commitIcon = 2130903133;
+			
+			// aapt resource value: 0x7F03005E
+			public const int contentInsetEnd = 2130903134;
+			
+			// aapt resource value: 0x7F03005F
+			public const int contentInsetEndWithActions = 2130903135;
+			
+			// aapt resource value: 0x7F030060
+			public const int contentInsetLeft = 2130903136;
+			
+			// aapt resource value: 0x7F030061
+			public const int contentInsetRight = 2130903137;
+			
+			// aapt resource value: 0x7F030062
+			public const int contentInsetStart = 2130903138;
+			
+			// aapt resource value: 0x7F030063
+			public const int contentInsetStartWithNavigation = 2130903139;
+			
+			// aapt resource value: 0x7F030064
+			public const int contentPadding = 2130903140;
+			
+			// aapt resource value: 0x7F030065
+			public const int contentPaddingBottom = 2130903141;
+			
+			// aapt resource value: 0x7F030066
+			public const int contentPaddingLeft = 2130903142;
+			
+			// aapt resource value: 0x7F030067
+			public const int contentPaddingRight = 2130903143;
+			
+			// aapt resource value: 0x7F030068
+			public const int contentPaddingTop = 2130903144;
+			
+			// aapt resource value: 0x7F030069
+			public const int contentScrim = 2130903145;
+			
+			// aapt resource value: 0x7F03006A
+			public const int controlBackground = 2130903146;
+			
+			// aapt resource value: 0x7F03006B
+			public const int counterEnabled = 2130903147;
+			
+			// aapt resource value: 0x7F03006C
+			public const int counterMaxLength = 2130903148;
+			
+			// aapt resource value: 0x7F03006D
+			public const int counterOverflowTextAppearance = 2130903149;
+			
+			// aapt resource value: 0x7F03006E
+			public const int counterTextAppearance = 2130903150;
+			
+			// aapt resource value: 0x7F03006F
+			public const int customNavigationLayout = 2130903151;
+			
+			// aapt resource value: 0x7F030070
+			public const int defaultQueryHint = 2130903152;
+			
+			// aapt resource value: 0x7F030071
+			public const int dialogPreferredPadding = 2130903153;
+			
+			// aapt resource value: 0x7F030072
+			public const int dialogTheme = 2130903154;
+			
+			// aapt resource value: 0x7F030073
+			public const int displayOptions = 2130903155;
+			
+			// aapt resource value: 0x7F030074
+			public const int divider = 2130903156;
+			
+			// aapt resource value: 0x7F030075
+			public const int dividerHorizontal = 2130903157;
+			
+			// aapt resource value: 0x7F030076
+			public const int dividerPadding = 2130903158;
+			
+			// aapt resource value: 0x7F030077
+			public const int dividerVertical = 2130903159;
+			
+			// aapt resource value: 0x7F030078
+			public const int drawableSize = 2130903160;
+			
+			// aapt resource value: 0x7F030079
+			public const int drawerArrowStyle = 2130903161;
+			
+			// aapt resource value: 0x7F03007B
+			public const int dropdownListPreferredItemHeight = 2130903163;
+			
+			// aapt resource value: 0x7F03007A
+			public const int dropDownListViewStyle = 2130903162;
+			
+			// aapt resource value: 0x7F03007C
+			public const int editTextBackground = 2130903164;
+			
+			// aapt resource value: 0x7F03007D
+			public const int editTextColor = 2130903165;
+			
+			// aapt resource value: 0x7F03007E
+			public const int editTextStyle = 2130903166;
+			
+			// aapt resource value: 0x7F03007F
+			public const int elevation = 2130903167;
+			
+			// aapt resource value: 0x7F030080
+			public const int errorEnabled = 2130903168;
+			
+			// aapt resource value: 0x7F030081
+			public const int errorTextAppearance = 2130903169;
+			
+			// aapt resource value: 0x7F030082
+			public const int expandActivityOverflowButtonDrawable = 2130903170;
+			
+			// aapt resource value: 0x7F030083
+			public const int expanded = 2130903171;
+			
+			// aapt resource value: 0x7F030084
+			public const int expandedTitleGravity = 2130903172;
+			
+			// aapt resource value: 0x7F030085
+			public const int expandedTitleMargin = 2130903173;
+			
+			// aapt resource value: 0x7F030086
+			public const int expandedTitleMarginBottom = 2130903174;
+			
+			// aapt resource value: 0x7F030087
+			public const int expandedTitleMarginEnd = 2130903175;
+			
+			// aapt resource value: 0x7F030088
+			public const int expandedTitleMarginStart = 2130903176;
+			
+			// aapt resource value: 0x7F030089
+			public const int expandedTitleMarginTop = 2130903177;
+			
+			// aapt resource value: 0x7F03008A
+			public const int expandedTitleTextAppearance = 2130903178;
+			
+			// aapt resource value: 0x7F03008B
+			public const int externalRouteEnabledDrawable = 2130903179;
+			
+			// aapt resource value: 0x7F03008C
+			public const int fabSize = 2130903180;
+			
+			// aapt resource value: 0x7F03008D
+			public const int foregroundInsidePadding = 2130903181;
+			
+			// aapt resource value: 0x7F03008E
+			public const int gapBetweenBars = 2130903182;
+			
+			// aapt resource value: 0x7F03008F
+			public const int goIcon = 2130903183;
+			
+			// aapt resource value: 0x7F030090
+			public const int headerLayout = 2130903184;
+			
+			// aapt resource value: 0x7F030091
+			public const int height = 2130903185;
+			
+			// aapt resource value: 0x7F030092
+			public const int hideOnContentScroll = 2130903186;
+			
+			// aapt resource value: 0x7F030093
+			public const int hintAnimationEnabled = 2130903187;
+			
+			// aapt resource value: 0x7F030094
+			public const int hintEnabled = 2130903188;
+			
+			// aapt resource value: 0x7F030095
+			public const int hintTextAppearance = 2130903189;
+			
+			// aapt resource value: 0x7F030096
+			public const int homeAsUpIndicator = 2130903190;
+			
+			// aapt resource value: 0x7F030097
+			public const int homeLayout = 2130903191;
+			
+			// aapt resource value: 0x7F030098
+			public const int icon = 2130903192;
+			
+			// aapt resource value: 0x7F030099
+			public const int iconifiedByDefault = 2130903193;
+			
+			// aapt resource value: 0x7F03009A
+			public const int imageButtonStyle = 2130903194;
+			
+			// aapt resource value: 0x7F03009B
+			public const int indeterminateProgressStyle = 2130903195;
+			
+			// aapt resource value: 0x7F03009C
+			public const int initialActivityCount = 2130903196;
+			
+			// aapt resource value: 0x7F03009D
+			public const int insetForeground = 2130903197;
+			
+			// aapt resource value: 0x7F03009E
+			public const int isLightTheme = 2130903198;
+			
+			// aapt resource value: 0x7F03009F
+			public const int itemBackground = 2130903199;
+			
+			// aapt resource value: 0x7F0300A0
+			public const int itemIconTint = 2130903200;
+			
+			// aapt resource value: 0x7F0300A1
+			public const int itemPadding = 2130903201;
+			
+			// aapt resource value: 0x7F0300A2
+			public const int itemTextAppearance = 2130903202;
+			
+			// aapt resource value: 0x7F0300A3
+			public const int itemTextColor = 2130903203;
+			
+			// aapt resource value: 0x7F0300A4
+			public const int keylines = 2130903204;
+			
+			// aapt resource value: 0x7F0300A5
+			public const int layout = 2130903205;
+			
+			// aapt resource value: 0x7F0300A6
+			public const int layoutManager = 2130903206;
+			
+			// aapt resource value: 0x7F0300A7
+			public const int layout_anchor = 2130903207;
+			
+			// aapt resource value: 0x7F0300A8
+			public const int layout_anchorGravity = 2130903208;
+			
+			// aapt resource value: 0x7F0300A9
+			public const int layout_behavior = 2130903209;
+			
+			// aapt resource value: 0x7F0300AA
+			public const int layout_collapseMode = 2130903210;
+			
+			// aapt resource value: 0x7F0300AB
+			public const int layout_collapseParallaxMultiplier = 2130903211;
+			
+			// aapt resource value: 0x7F0300AC
+			public const int layout_dodgeInsetEdges = 2130903212;
+			
+			// aapt resource value: 0x7F0300AD
+			public const int layout_insetEdge = 2130903213;
+			
+			// aapt resource value: 0x7F0300AE
+			public const int layout_keyline = 2130903214;
+			
+			// aapt resource value: 0x7F0300AF
+			public const int layout_scrollFlags = 2130903215;
+			
+			// aapt resource value: 0x7F0300B0
+			public const int layout_scrollInterpolator = 2130903216;
+			
+			// aapt resource value: 0x7F0300B1
+			public const int listChoiceBackgroundIndicator = 2130903217;
+			
+			// aapt resource value: 0x7F0300B2
+			public const int listDividerAlertDialog = 2130903218;
+			
+			// aapt resource value: 0x7F0300B3
+			public const int listItemLayout = 2130903219;
+			
+			// aapt resource value: 0x7F0300B4
+			public const int listLayout = 2130903220;
+			
+			// aapt resource value: 0x7F0300B5
+			public const int listMenuViewStyle = 2130903221;
+			
+			// aapt resource value: 0x7F0300B6
+			public const int listPopupWindowStyle = 2130903222;
+			
+			// aapt resource value: 0x7F0300B7
+			public const int listPreferredItemHeight = 2130903223;
+			
+			// aapt resource value: 0x7F0300B8
+			public const int listPreferredItemHeightLarge = 2130903224;
+			
+			// aapt resource value: 0x7F0300B9
+			public const int listPreferredItemHeightSmall = 2130903225;
+			
+			// aapt resource value: 0x7F0300BA
+			public const int listPreferredItemPaddingLeft = 2130903226;
+			
+			// aapt resource value: 0x7F0300BB
+			public const int listPreferredItemPaddingRight = 2130903227;
+			
+			// aapt resource value: 0x7F0300BC
+			public const int logo = 2130903228;
+			
+			// aapt resource value: 0x7F0300BD
+			public const int logoDescription = 2130903229;
+			
+			// aapt resource value: 0x7F0300BE
+			public const int maxActionInlineWidth = 2130903230;
+			
+			// aapt resource value: 0x7F0300BF
+			public const int maxButtonHeight = 2130903231;
+			
+			// aapt resource value: 0x7F0300C0
+			public const int measureWithLargestChild = 2130903232;
+			
+			// aapt resource value: 0x7F0300C1
+			public const int mediaRouteAudioTrackDrawable = 2130903233;
+			
+			// aapt resource value: 0x7F0300C2
+			public const int mediaRouteButtonStyle = 2130903234;
+			
+			// aapt resource value: 0x7F0300C3
+			public const int mediaRouteCloseDrawable = 2130903235;
+			
+			// aapt resource value: 0x7F0300C4
+			public const int mediaRouteControlPanelThemeOverlay = 2130903236;
+			
+			// aapt resource value: 0x7F0300C5
+			public const int mediaRouteDefaultIconDrawable = 2130903237;
+			
+			// aapt resource value: 0x7F0300C6
+			public const int mediaRoutePauseDrawable = 2130903238;
+			
+			// aapt resource value: 0x7F0300C7
+			public const int mediaRoutePlayDrawable = 2130903239;
+			
+			// aapt resource value: 0x7F0300C8
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130903240;
+			
+			// aapt resource value: 0x7F0300C9
+			public const int mediaRouteSpeakerIconDrawable = 2130903241;
+			
+			// aapt resource value: 0x7F0300CA
+			public const int mediaRouteStopDrawable = 2130903242;
+			
+			// aapt resource value: 0x7F0300CB
+			public const int mediaRouteTheme = 2130903243;
+			
+			// aapt resource value: 0x7F0300CC
+			public const int mediaRouteTvIconDrawable = 2130903244;
+			
+			// aapt resource value: 0x7F0300CD
+			public const int menu = 2130903245;
+			
+			// aapt resource value: 0x7F0300CE
+			public const int multiChoiceItemLayout = 2130903246;
+			
+			// aapt resource value: 0x7F0300CF
+			public const int navigationContentDescription = 2130903247;
+			
+			// aapt resource value: 0x7F0300D0
+			public const int navigationIcon = 2130903248;
+			
+			// aapt resource value: 0x7F0300D1
+			public const int navigationMode = 2130903249;
+			
+			// aapt resource value: 0x7F0300D2
+			public const int overlapAnchor = 2130903250;
+			
+			// aapt resource value: 0x7F0300D3
+			public const int paddingBottomNoButtons = 2130903251;
+			
+			// aapt resource value: 0x7F0300D4
+			public const int paddingEnd = 2130903252;
+			
+			// aapt resource value: 0x7F0300D5
+			public const int paddingStart = 2130903253;
+			
+			// aapt resource value: 0x7F0300D6
+			public const int paddingTopNoTitle = 2130903254;
+			
+			// aapt resource value: 0x7F0300D7
+			public const int panelBackground = 2130903255;
+			
+			// aapt resource value: 0x7F0300D8
+			public const int panelMenuListTheme = 2130903256;
+			
+			// aapt resource value: 0x7F0300D9
+			public const int panelMenuListWidth = 2130903257;
+			
+			// aapt resource value: 0x7F0300DA
+			public const int passwordToggleContentDescription = 2130903258;
+			
+			// aapt resource value: 0x7F0300DB
+			public const int passwordToggleDrawable = 2130903259;
+			
+			// aapt resource value: 0x7F0300DC
+			public const int passwordToggleEnabled = 2130903260;
+			
+			// aapt resource value: 0x7F0300DD
+			public const int passwordToggleTint = 2130903261;
+			
+			// aapt resource value: 0x7F0300DE
+			public const int passwordToggleTintMode = 2130903262;
+			
+			// aapt resource value: 0x7F0300DF
+			public const int popupMenuStyle = 2130903263;
+			
+			// aapt resource value: 0x7F0300E0
+			public const int popupTheme = 2130903264;
+			
+			// aapt resource value: 0x7F0300E1
+			public const int popupWindowStyle = 2130903265;
+			
+			// aapt resource value: 0x7F0300E2
+			public const int preserveIconSpacing = 2130903266;
+			
+			// aapt resource value: 0x7F0300E3
+			public const int pressedTranslationZ = 2130903267;
+			
+			// aapt resource value: 0x7F0300E4
+			public const int progressBarPadding = 2130903268;
+			
+			// aapt resource value: 0x7F0300E5
+			public const int progressBarStyle = 2130903269;
+			
+			// aapt resource value: 0x7F0300E6
+			public const int queryBackground = 2130903270;
+			
+			// aapt resource value: 0x7F0300E7
+			public const int queryHint = 2130903271;
+			
+			// aapt resource value: 0x7F0300E8
+			public const int radioButtonStyle = 2130903272;
+			
+			// aapt resource value: 0x7F0300E9
+			public const int ratingBarStyle = 2130903273;
+			
+			// aapt resource value: 0x7F0300EA
+			public const int ratingBarStyleIndicator = 2130903274;
+			
+			// aapt resource value: 0x7F0300EB
+			public const int ratingBarStyleSmall = 2130903275;
+			
+			// aapt resource value: 0x7F0300EC
+			public const int reverseLayout = 2130903276;
+			
+			// aapt resource value: 0x7F0300ED
+			public const int rippleColor = 2130903277;
+			
+			// aapt resource value: 0x7F0300EE
+			public const int scrimAnimationDuration = 2130903278;
+			
+			// aapt resource value: 0x7F0300EF
+			public const int scrimVisibleHeightTrigger = 2130903279;
+			
+			// aapt resource value: 0x7F0300F0
+			public const int searchHintIcon = 2130903280;
+			
+			// aapt resource value: 0x7F0300F1
+			public const int searchIcon = 2130903281;
+			
+			// aapt resource value: 0x7F0300F2
+			public const int searchViewStyle = 2130903282;
+			
+			// aapt resource value: 0x7F0300F3
+			public const int seekBarStyle = 2130903283;
+			
+			// aapt resource value: 0x7F0300F4
+			public const int selectableItemBackground = 2130903284;
+			
+			// aapt resource value: 0x7F0300F5
+			public const int selectableItemBackgroundBorderless = 2130903285;
+			
+			// aapt resource value: 0x7F0300F6
+			public const int showAsAction = 2130903286;
+			
+			// aapt resource value: 0x7F0300F7
+			public const int showDividers = 2130903287;
+			
+			// aapt resource value: 0x7F0300F8
+			public const int showText = 2130903288;
+			
+			// aapt resource value: 0x7F0300F9
+			public const int showTitle = 2130903289;
+			
+			// aapt resource value: 0x7F0300FA
+			public const int singleChoiceItemLayout = 2130903290;
+			
+			// aapt resource value: 0x7F0300FB
+			public const int spanCount = 2130903291;
+			
+			// aapt resource value: 0x7F0300FC
+			public const int spinBars = 2130903292;
+			
+			// aapt resource value: 0x7F0300FD
+			public const int spinnerDropDownItemStyle = 2130903293;
+			
+			// aapt resource value: 0x7F0300FE
+			public const int spinnerStyle = 2130903294;
+			
+			// aapt resource value: 0x7F0300FF
+			public const int splitTrack = 2130903295;
+			
+			// aapt resource value: 0x7F030100
+			public const int srcCompat = 2130903296;
+			
+			// aapt resource value: 0x7F030101
+			public const int stackFromEnd = 2130903297;
+			
+			// aapt resource value: 0x7F030102
+			public const int state_above_anchor = 2130903298;
+			
+			// aapt resource value: 0x7F030103
+			public const int state_collapsed = 2130903299;
+			
+			// aapt resource value: 0x7F030104
+			public const int state_collapsible = 2130903300;
+			
+			// aapt resource value: 0x7F030105
+			public const int statusBarBackground = 2130903301;
+			
+			// aapt resource value: 0x7F030106
+			public const int statusBarScrim = 2130903302;
+			
+			// aapt resource value: 0x7F030107
+			public const int subMenuArrow = 2130903303;
+			
+			// aapt resource value: 0x7F030108
+			public const int submitBackground = 2130903304;
+			
+			// aapt resource value: 0x7F030109
+			public const int subtitle = 2130903305;
+			
+			// aapt resource value: 0x7F03010A
+			public const int subtitleTextAppearance = 2130903306;
+			
+			// aapt resource value: 0x7F03010B
+			public const int subtitleTextColor = 2130903307;
+			
+			// aapt resource value: 0x7F03010C
+			public const int subtitleTextStyle = 2130903308;
+			
+			// aapt resource value: 0x7F03010D
+			public const int suggestionRowLayout = 2130903309;
+			
+			// aapt resource value: 0x7F03010E
+			public const int switchMinWidth = 2130903310;
+			
+			// aapt resource value: 0x7F03010F
+			public const int switchPadding = 2130903311;
+			
+			// aapt resource value: 0x7F030110
+			public const int switchStyle = 2130903312;
+			
+			// aapt resource value: 0x7F030111
+			public const int switchTextAppearance = 2130903313;
+			
+			// aapt resource value: 0x7F030112
+			public const int tabBackground = 2130903314;
+			
+			// aapt resource value: 0x7F030113
+			public const int tabContentStart = 2130903315;
+			
+			// aapt resource value: 0x7F030114
+			public const int tabGravity = 2130903316;
+			
+			// aapt resource value: 0x7F030115
+			public const int tabIndicatorColor = 2130903317;
+			
+			// aapt resource value: 0x7F030116
+			public const int tabIndicatorHeight = 2130903318;
+			
+			// aapt resource value: 0x7F030117
+			public const int tabMaxWidth = 2130903319;
+			
+			// aapt resource value: 0x7F030118
+			public const int tabMinWidth = 2130903320;
+			
+			// aapt resource value: 0x7F030119
+			public const int tabMode = 2130903321;
+			
+			// aapt resource value: 0x7F03011A
+			public const int tabPadding = 2130903322;
+			
+			// aapt resource value: 0x7F03011B
+			public const int tabPaddingBottom = 2130903323;
+			
+			// aapt resource value: 0x7F03011C
+			public const int tabPaddingEnd = 2130903324;
+			
+			// aapt resource value: 0x7F03011D
+			public const int tabPaddingStart = 2130903325;
+			
+			// aapt resource value: 0x7F03011E
+			public const int tabPaddingTop = 2130903326;
+			
+			// aapt resource value: 0x7F03011F
+			public const int tabSelectedTextColor = 2130903327;
+			
+			// aapt resource value: 0x7F030120
+			public const int tabTextAppearance = 2130903328;
+			
+			// aapt resource value: 0x7F030121
+			public const int tabTextColor = 2130903329;
+			
+			// aapt resource value: 0x7F030122
+			public const int textAllCaps = 2130903330;
+			
+			// aapt resource value: 0x7F030123
+			public const int textAppearanceLargePopupMenu = 2130903331;
+			
+			// aapt resource value: 0x7F030124
+			public const int textAppearanceListItem = 2130903332;
+			
+			// aapt resource value: 0x7F030125
+			public const int textAppearanceListItemSecondary = 2130903333;
+			
+			// aapt resource value: 0x7F030126
+			public const int textAppearanceListItemSmall = 2130903334;
+			
+			// aapt resource value: 0x7F030127
+			public const int textAppearancePopupMenuHeader = 2130903335;
+			
+			// aapt resource value: 0x7F030128
+			public const int textAppearanceSearchResultSubtitle = 2130903336;
+			
+			// aapt resource value: 0x7F030129
+			public const int textAppearanceSearchResultTitle = 2130903337;
+			
+			// aapt resource value: 0x7F03012A
+			public const int textAppearanceSmallPopupMenu = 2130903338;
+			
+			// aapt resource value: 0x7F03012B
+			public const int textColorAlertDialogListItem = 2130903339;
+			
+			// aapt resource value: 0x7F03012C
+			public const int textColorError = 2130903340;
+			
+			// aapt resource value: 0x7F03012D
+			public const int textColorSearchUrl = 2130903341;
+			
+			// aapt resource value: 0x7F03012E
+			public const int theme = 2130903342;
+			
+			// aapt resource value: 0x7F03012F
+			public const int thickness = 2130903343;
+			
+			// aapt resource value: 0x7F030130
+			public const int thumbTextPadding = 2130903344;
+			
+			// aapt resource value: 0x7F030131
+			public const int thumbTint = 2130903345;
+			
+			// aapt resource value: 0x7F030132
+			public const int thumbTintMode = 2130903346;
+			
+			// aapt resource value: 0x7F030133
+			public const int tickMark = 2130903347;
+			
+			// aapt resource value: 0x7F030134
+			public const int tickMarkTint = 2130903348;
+			
+			// aapt resource value: 0x7F030135
+			public const int tickMarkTintMode = 2130903349;
+			
+			// aapt resource value: 0x7F030136
+			public const int tint = 2130903350;
+			
+			// aapt resource value: 0x7F030137
+			public const int tintMode = 2130903351;
+			
+			// aapt resource value: 0x7F030138
+			public const int title = 2130903352;
+			
+			// aapt resource value: 0x7F030139
+			public const int titleEnabled = 2130903353;
+			
+			// aapt resource value: 0x7F03013A
+			public const int titleMargin = 2130903354;
+			
+			// aapt resource value: 0x7F03013B
+			public const int titleMarginBottom = 2130903355;
+			
+			// aapt resource value: 0x7F03013C
+			public const int titleMarginEnd = 2130903356;
+			
+			// aapt resource value: 0x7F03013F
+			public const int titleMargins = 2130903359;
+			
+			// aapt resource value: 0x7F03013D
+			public const int titleMarginStart = 2130903357;
+			
+			// aapt resource value: 0x7F03013E
+			public const int titleMarginTop = 2130903358;
+			
+			// aapt resource value: 0x7F030140
+			public const int titleTextAppearance = 2130903360;
+			
+			// aapt resource value: 0x7F030141
+			public const int titleTextColor = 2130903361;
+			
+			// aapt resource value: 0x7F030142
+			public const int titleTextStyle = 2130903362;
+			
+			// aapt resource value: 0x7F030143
+			public const int toolbarId = 2130903363;
+			
+			// aapt resource value: 0x7F030144
+			public const int toolbarNavigationButtonStyle = 2130903364;
+			
+			// aapt resource value: 0x7F030145
+			public const int toolbarStyle = 2130903365;
+			
+			// aapt resource value: 0x7F030146
+			public const int track = 2130903366;
+			
+			// aapt resource value: 0x7F030147
+			public const int trackTint = 2130903367;
+			
+			// aapt resource value: 0x7F030148
+			public const int trackTintMode = 2130903368;
+			
+			// aapt resource value: 0x7F030149
+			public const int useCompatPadding = 2130903369;
+			
+			// aapt resource value: 0x7F03014A
+			public const int voiceIcon = 2130903370;
+			
+			// aapt resource value: 0x7F03014B
+			public const int windowActionBar = 2130903371;
+			
+			// aapt resource value: 0x7F03014C
+			public const int windowActionBarOverlay = 2130903372;
+			
+			// aapt resource value: 0x7F03014D
+			public const int windowActionModeOverlay = 2130903373;
+			
+			// aapt resource value: 0x7F03014E
+			public const int windowFixedHeightMajor = 2130903374;
+			
+			// aapt resource value: 0x7F03014F
+			public const int windowFixedHeightMinor = 2130903375;
+			
+			// aapt resource value: 0x7F030150
+			public const int windowFixedWidthMajor = 2130903376;
+			
+			// aapt resource value: 0x7F030151
+			public const int windowFixedWidthMinor = 2130903377;
+			
+			// aapt resource value: 0x7F030152
+			public const int windowMinWidthMajor = 2130903378;
+			
+			// aapt resource value: 0x7F030153
+			public const int windowMinWidthMinor = 2130903379;
+			
+			// aapt resource value: 0x7F030154
+			public const int windowNoTitle = 2130903380;
 			
 			static Attribute()
 			{
@@ -40,20 +1141,345 @@ namespace Features.Forms.Droid
 			}
 		}
 		
+		public partial class Boolean
+		{
+			
+			// aapt resource value: 0x7F040000
+			public const int abc_action_bar_embed_tabs = 2130968576;
+			
+			// aapt resource value: 0x7F040001
+			public const int abc_allow_stacked_button_bar = 2130968577;
+			
+			// aapt resource value: 0x7F040002
+			public const int abc_config_actionMenuItemAllCaps = 2130968578;
+			
+			// aapt resource value: 0x7F040003
+			public const int abc_config_closeDialogWhenTouchOutside = 2130968579;
+			
+			// aapt resource value: 0x7F040004
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2130968580;
+			
+			static Boolean()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Boolean()
+			{
+			}
+		}
+		
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7F010000
-			public const int colorAccent = 2130771968;
+			// aapt resource value: 0x7F050000
+			public const int abc_background_cache_hint_selector_material_dark = 2131034112;
 			
-			// aapt resource value: 0x7F010001
-			public const int colorPrimary = 2130771969;
+			// aapt resource value: 0x7F050001
+			public const int abc_background_cache_hint_selector_material_light = 2131034113;
 			
-			// aapt resource value: 0x7F010002
-			public const int colorPrimaryDark = 2130771970;
+			// aapt resource value: 0x7F050002
+			public const int abc_btn_colored_borderless_text_material = 2131034114;
 			
-			// aapt resource value: 0x7F010003
-			public const int launcher_background = 2130771971;
+			// aapt resource value: 0x7F050003
+			public const int abc_btn_colored_text_material = 2131034115;
+			
+			// aapt resource value: 0x7F050004
+			public const int abc_color_highlight_material = 2131034116;
+			
+			// aapt resource value: 0x7F050005
+			public const int abc_hint_foreground_material_dark = 2131034117;
+			
+			// aapt resource value: 0x7F050006
+			public const int abc_hint_foreground_material_light = 2131034118;
+			
+			// aapt resource value: 0x7F050007
+			public const int abc_input_method_navigation_guard = 2131034119;
+			
+			// aapt resource value: 0x7F050008
+			public const int abc_primary_text_disable_only_material_dark = 2131034120;
+			
+			// aapt resource value: 0x7F050009
+			public const int abc_primary_text_disable_only_material_light = 2131034121;
+			
+			// aapt resource value: 0x7F05000A
+			public const int abc_primary_text_material_dark = 2131034122;
+			
+			// aapt resource value: 0x7F05000B
+			public const int abc_primary_text_material_light = 2131034123;
+			
+			// aapt resource value: 0x7F05000C
+			public const int abc_search_url_text = 2131034124;
+			
+			// aapt resource value: 0x7F05000D
+			public const int abc_search_url_text_normal = 2131034125;
+			
+			// aapt resource value: 0x7F05000E
+			public const int abc_search_url_text_pressed = 2131034126;
+			
+			// aapt resource value: 0x7F05000F
+			public const int abc_search_url_text_selected = 2131034127;
+			
+			// aapt resource value: 0x7F050010
+			public const int abc_secondary_text_material_dark = 2131034128;
+			
+			// aapt resource value: 0x7F050011
+			public const int abc_secondary_text_material_light = 2131034129;
+			
+			// aapt resource value: 0x7F050012
+			public const int abc_tint_btn_checkable = 2131034130;
+			
+			// aapt resource value: 0x7F050013
+			public const int abc_tint_default = 2131034131;
+			
+			// aapt resource value: 0x7F050014
+			public const int abc_tint_edittext = 2131034132;
+			
+			// aapt resource value: 0x7F050015
+			public const int abc_tint_seek_thumb = 2131034133;
+			
+			// aapt resource value: 0x7F050016
+			public const int abc_tint_spinner = 2131034134;
+			
+			// aapt resource value: 0x7F050017
+			public const int abc_tint_switch_thumb = 2131034135;
+			
+			// aapt resource value: 0x7F050018
+			public const int abc_tint_switch_track = 2131034136;
+			
+			// aapt resource value: 0x7F050019
+			public const int accent_material_dark = 2131034137;
+			
+			// aapt resource value: 0x7F05001A
+			public const int accent_material_light = 2131034138;
+			
+			// aapt resource value: 0x7F05001B
+			public const int background_floating_material_dark = 2131034139;
+			
+			// aapt resource value: 0x7F05001C
+			public const int background_floating_material_light = 2131034140;
+			
+			// aapt resource value: 0x7F05001D
+			public const int background_material_dark = 2131034141;
+			
+			// aapt resource value: 0x7F05001E
+			public const int background_material_light = 2131034142;
+			
+			// aapt resource value: 0x7F05001F
+			public const int bright_foreground_disabled_material_dark = 2131034143;
+			
+			// aapt resource value: 0x7F050020
+			public const int bright_foreground_disabled_material_light = 2131034144;
+			
+			// aapt resource value: 0x7F050021
+			public const int bright_foreground_inverse_material_dark = 2131034145;
+			
+			// aapt resource value: 0x7F050022
+			public const int bright_foreground_inverse_material_light = 2131034146;
+			
+			// aapt resource value: 0x7F050023
+			public const int bright_foreground_material_dark = 2131034147;
+			
+			// aapt resource value: 0x7F050024
+			public const int bright_foreground_material_light = 2131034148;
+			
+			// aapt resource value: 0x7F050025
+			public const int button_material_dark = 2131034149;
+			
+			// aapt resource value: 0x7F050026
+			public const int button_material_light = 2131034150;
+			
+			// aapt resource value: 0x7F050027
+			public const int cardview_dark_background = 2131034151;
+			
+			// aapt resource value: 0x7F050028
+			public const int cardview_light_background = 2131034152;
+			
+			// aapt resource value: 0x7F050029
+			public const int cardview_shadow_end_color = 2131034153;
+			
+			// aapt resource value: 0x7F05002A
+			public const int cardview_shadow_start_color = 2131034154;
+			
+			// aapt resource value: 0x7F05002B
+			public const int colorAccent = 2131034155;
+			
+			// aapt resource value: 0x7F05002C
+			public const int colorPrimary = 2131034156;
+			
+			// aapt resource value: 0x7F05002D
+			public const int colorPrimaryDark = 2131034157;
+			
+			// aapt resource value: 0x7F05002E
+			public const int design_bottom_navigation_shadow_color = 2131034158;
+			
+			// aapt resource value: 0x7F05002F
+			public const int design_error = 2131034159;
+			
+			// aapt resource value: 0x7F050030
+			public const int design_fab_shadow_end_color = 2131034160;
+			
+			// aapt resource value: 0x7F050031
+			public const int design_fab_shadow_mid_color = 2131034161;
+			
+			// aapt resource value: 0x7F050032
+			public const int design_fab_shadow_start_color = 2131034162;
+			
+			// aapt resource value: 0x7F050033
+			public const int design_fab_stroke_end_inner_color = 2131034163;
+			
+			// aapt resource value: 0x7F050034
+			public const int design_fab_stroke_end_outer_color = 2131034164;
+			
+			// aapt resource value: 0x7F050035
+			public const int design_fab_stroke_top_inner_color = 2131034165;
+			
+			// aapt resource value: 0x7F050036
+			public const int design_fab_stroke_top_outer_color = 2131034166;
+			
+			// aapt resource value: 0x7F050037
+			public const int design_snackbar_background_color = 2131034167;
+			
+			// aapt resource value: 0x7F050038
+			public const int design_textinput_error_color_dark = 2131034168;
+			
+			// aapt resource value: 0x7F050039
+			public const int design_textinput_error_color_light = 2131034169;
+			
+			// aapt resource value: 0x7F05003A
+			public const int design_tint_password_toggle = 2131034170;
+			
+			// aapt resource value: 0x7F05003B
+			public const int dim_foreground_disabled_material_dark = 2131034171;
+			
+			// aapt resource value: 0x7F05003C
+			public const int dim_foreground_disabled_material_light = 2131034172;
+			
+			// aapt resource value: 0x7F05003D
+			public const int dim_foreground_material_dark = 2131034173;
+			
+			// aapt resource value: 0x7F05003E
+			public const int dim_foreground_material_light = 2131034174;
+			
+			// aapt resource value: 0x7F05003F
+			public const int foreground_material_dark = 2131034175;
+			
+			// aapt resource value: 0x7F050040
+			public const int foreground_material_light = 2131034176;
+			
+			// aapt resource value: 0x7F050041
+			public const int highlighted_text_material_dark = 2131034177;
+			
+			// aapt resource value: 0x7F050042
+			public const int highlighted_text_material_light = 2131034178;
+			
+			// aapt resource value: 0x7F050043
+			public const int launcher_background = 2131034179;
+			
+			// aapt resource value: 0x7F050044
+			public const int material_blue_grey_800 = 2131034180;
+			
+			// aapt resource value: 0x7F050045
+			public const int material_blue_grey_900 = 2131034181;
+			
+			// aapt resource value: 0x7F050046
+			public const int material_blue_grey_950 = 2131034182;
+			
+			// aapt resource value: 0x7F050047
+			public const int material_deep_teal_200 = 2131034183;
+			
+			// aapt resource value: 0x7F050048
+			public const int material_deep_teal_500 = 2131034184;
+			
+			// aapt resource value: 0x7F050049
+			public const int material_grey_100 = 2131034185;
+			
+			// aapt resource value: 0x7F05004A
+			public const int material_grey_300 = 2131034186;
+			
+			// aapt resource value: 0x7F05004B
+			public const int material_grey_50 = 2131034187;
+			
+			// aapt resource value: 0x7F05004C
+			public const int material_grey_600 = 2131034188;
+			
+			// aapt resource value: 0x7F05004D
+			public const int material_grey_800 = 2131034189;
+			
+			// aapt resource value: 0x7F05004E
+			public const int material_grey_850 = 2131034190;
+			
+			// aapt resource value: 0x7F05004F
+			public const int material_grey_900 = 2131034191;
+			
+			// aapt resource value: 0x7F050050
+			public const int notification_action_color_filter = 2131034192;
+			
+			// aapt resource value: 0x7F050051
+			public const int notification_icon_bg_color = 2131034193;
+			
+			// aapt resource value: 0x7F050052
+			public const int notification_material_background_media_default_color = 2131034194;
+			
+			// aapt resource value: 0x7F050053
+			public const int primary_dark_material_dark = 2131034195;
+			
+			// aapt resource value: 0x7F050054
+			public const int primary_dark_material_light = 2131034196;
+			
+			// aapt resource value: 0x7F050055
+			public const int primary_material_dark = 2131034197;
+			
+			// aapt resource value: 0x7F050056
+			public const int primary_material_light = 2131034198;
+			
+			// aapt resource value: 0x7F050057
+			public const int primary_text_default_material_dark = 2131034199;
+			
+			// aapt resource value: 0x7F050058
+			public const int primary_text_default_material_light = 2131034200;
+			
+			// aapt resource value: 0x7F050059
+			public const int primary_text_disabled_material_dark = 2131034201;
+			
+			// aapt resource value: 0x7F05005A
+			public const int primary_text_disabled_material_light = 2131034202;
+			
+			// aapt resource value: 0x7F05005B
+			public const int ripple_material_dark = 2131034203;
+			
+			// aapt resource value: 0x7F05005C
+			public const int ripple_material_light = 2131034204;
+			
+			// aapt resource value: 0x7F05005D
+			public const int secondary_text_default_material_dark = 2131034205;
+			
+			// aapt resource value: 0x7F05005E
+			public const int secondary_text_default_material_light = 2131034206;
+			
+			// aapt resource value: 0x7F05005F
+			public const int secondary_text_disabled_material_dark = 2131034207;
+			
+			// aapt resource value: 0x7F050060
+			public const int secondary_text_disabled_material_light = 2131034208;
+			
+			// aapt resource value: 0x7F050061
+			public const int switch_thumb_disabled_material_dark = 2131034209;
+			
+			// aapt resource value: 0x7F050062
+			public const int switch_thumb_disabled_material_light = 2131034210;
+			
+			// aapt resource value: 0x7F050063
+			public const int switch_thumb_material_dark = 2131034211;
+			
+			// aapt resource value: 0x7F050064
+			public const int switch_thumb_material_light = 2131034212;
+			
+			// aapt resource value: 0x7F050065
+			public const int switch_thumb_normal_material_dark = 2131034213;
+			
+			// aapt resource value: 0x7F050066
+			public const int switch_thumb_normal_material_light = 2131034214;
 			
 			static Color()
 			{
@@ -65,14 +1491,1831 @@ namespace Features.Forms.Droid
 			}
 		}
 		
+		public partial class Dimension
+		{
+			
+			// aapt resource value: 0x7F060000
+			public const int abc_action_bar_content_inset_material = 2131099648;
+			
+			// aapt resource value: 0x7F060001
+			public const int abc_action_bar_content_inset_with_nav = 2131099649;
+			
+			// aapt resource value: 0x7F060002
+			public const int abc_action_bar_default_height_material = 2131099650;
+			
+			// aapt resource value: 0x7F060003
+			public const int abc_action_bar_default_padding_end_material = 2131099651;
+			
+			// aapt resource value: 0x7F060004
+			public const int abc_action_bar_default_padding_start_material = 2131099652;
+			
+			// aapt resource value: 0x7F060005
+			public const int abc_action_bar_elevation_material = 2131099653;
+			
+			// aapt resource value: 0x7F060006
+			public const int abc_action_bar_icon_vertical_padding_material = 2131099654;
+			
+			// aapt resource value: 0x7F060007
+			public const int abc_action_bar_overflow_padding_end_material = 2131099655;
+			
+			// aapt resource value: 0x7F060008
+			public const int abc_action_bar_overflow_padding_start_material = 2131099656;
+			
+			// aapt resource value: 0x7F060009
+			public const int abc_action_bar_progress_bar_size = 2131099657;
+			
+			// aapt resource value: 0x7F06000A
+			public const int abc_action_bar_stacked_max_height = 2131099658;
+			
+			// aapt resource value: 0x7F06000B
+			public const int abc_action_bar_stacked_tab_max_width = 2131099659;
+			
+			// aapt resource value: 0x7F06000C
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099660;
+			
+			// aapt resource value: 0x7F06000D
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099661;
+			
+			// aapt resource value: 0x7F06000E
+			public const int abc_action_button_min_height_material = 2131099662;
+			
+			// aapt resource value: 0x7F06000F
+			public const int abc_action_button_min_width_material = 2131099663;
+			
+			// aapt resource value: 0x7F060010
+			public const int abc_action_button_min_width_overflow_material = 2131099664;
+			
+			// aapt resource value: 0x7F060011
+			public const int abc_alert_dialog_button_bar_height = 2131099665;
+			
+			// aapt resource value: 0x7F060012
+			public const int abc_button_inset_horizontal_material = 2131099666;
+			
+			// aapt resource value: 0x7F060013
+			public const int abc_button_inset_vertical_material = 2131099667;
+			
+			// aapt resource value: 0x7F060014
+			public const int abc_button_padding_horizontal_material = 2131099668;
+			
+			// aapt resource value: 0x7F060015
+			public const int abc_button_padding_vertical_material = 2131099669;
+			
+			// aapt resource value: 0x7F060016
+			public const int abc_cascading_menus_min_smallest_width = 2131099670;
+			
+			// aapt resource value: 0x7F060017
+			public const int abc_config_prefDialogWidth = 2131099671;
+			
+			// aapt resource value: 0x7F060018
+			public const int abc_control_corner_material = 2131099672;
+			
+			// aapt resource value: 0x7F060019
+			public const int abc_control_inset_material = 2131099673;
+			
+			// aapt resource value: 0x7F06001A
+			public const int abc_control_padding_material = 2131099674;
+			
+			// aapt resource value: 0x7F06001B
+			public const int abc_dialog_fixed_height_major = 2131099675;
+			
+			// aapt resource value: 0x7F06001C
+			public const int abc_dialog_fixed_height_minor = 2131099676;
+			
+			// aapt resource value: 0x7F06001D
+			public const int abc_dialog_fixed_width_major = 2131099677;
+			
+			// aapt resource value: 0x7F06001E
+			public const int abc_dialog_fixed_width_minor = 2131099678;
+			
+			// aapt resource value: 0x7F06001F
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131099679;
+			
+			// aapt resource value: 0x7F060020
+			public const int abc_dialog_list_padding_top_no_title = 2131099680;
+			
+			// aapt resource value: 0x7F060021
+			public const int abc_dialog_min_width_major = 2131099681;
+			
+			// aapt resource value: 0x7F060022
+			public const int abc_dialog_min_width_minor = 2131099682;
+			
+			// aapt resource value: 0x7F060023
+			public const int abc_dialog_padding_material = 2131099683;
+			
+			// aapt resource value: 0x7F060024
+			public const int abc_dialog_padding_top_material = 2131099684;
+			
+			// aapt resource value: 0x7F060025
+			public const int abc_dialog_title_divider_material = 2131099685;
+			
+			// aapt resource value: 0x7F060026
+			public const int abc_disabled_alpha_material_dark = 2131099686;
+			
+			// aapt resource value: 0x7F060027
+			public const int abc_disabled_alpha_material_light = 2131099687;
+			
+			// aapt resource value: 0x7F060028
+			public const int abc_dropdownitem_icon_width = 2131099688;
+			
+			// aapt resource value: 0x7F060029
+			public const int abc_dropdownitem_text_padding_left = 2131099689;
+			
+			// aapt resource value: 0x7F06002A
+			public const int abc_dropdownitem_text_padding_right = 2131099690;
+			
+			// aapt resource value: 0x7F06002B
+			public const int abc_edit_text_inset_bottom_material = 2131099691;
+			
+			// aapt resource value: 0x7F06002C
+			public const int abc_edit_text_inset_horizontal_material = 2131099692;
+			
+			// aapt resource value: 0x7F06002D
+			public const int abc_edit_text_inset_top_material = 2131099693;
+			
+			// aapt resource value: 0x7F06002E
+			public const int abc_floating_window_z = 2131099694;
+			
+			// aapt resource value: 0x7F06002F
+			public const int abc_list_item_padding_horizontal_material = 2131099695;
+			
+			// aapt resource value: 0x7F060030
+			public const int abc_panel_menu_list_width = 2131099696;
+			
+			// aapt resource value: 0x7F060031
+			public const int abc_progress_bar_height_material = 2131099697;
+			
+			// aapt resource value: 0x7F060032
+			public const int abc_search_view_preferred_height = 2131099698;
+			
+			// aapt resource value: 0x7F060033
+			public const int abc_search_view_preferred_width = 2131099699;
+			
+			// aapt resource value: 0x7F060034
+			public const int abc_seekbar_track_background_height_material = 2131099700;
+			
+			// aapt resource value: 0x7F060035
+			public const int abc_seekbar_track_progress_height_material = 2131099701;
+			
+			// aapt resource value: 0x7F060036
+			public const int abc_select_dialog_padding_start_material = 2131099702;
+			
+			// aapt resource value: 0x7F060037
+			public const int abc_switch_padding = 2131099703;
+			
+			// aapt resource value: 0x7F060038
+			public const int abc_text_size_body_1_material = 2131099704;
+			
+			// aapt resource value: 0x7F060039
+			public const int abc_text_size_body_2_material = 2131099705;
+			
+			// aapt resource value: 0x7F06003A
+			public const int abc_text_size_button_material = 2131099706;
+			
+			// aapt resource value: 0x7F06003B
+			public const int abc_text_size_caption_material = 2131099707;
+			
+			// aapt resource value: 0x7F06003C
+			public const int abc_text_size_display_1_material = 2131099708;
+			
+			// aapt resource value: 0x7F06003D
+			public const int abc_text_size_display_2_material = 2131099709;
+			
+			// aapt resource value: 0x7F06003E
+			public const int abc_text_size_display_3_material = 2131099710;
+			
+			// aapt resource value: 0x7F06003F
+			public const int abc_text_size_display_4_material = 2131099711;
+			
+			// aapt resource value: 0x7F060040
+			public const int abc_text_size_headline_material = 2131099712;
+			
+			// aapt resource value: 0x7F060041
+			public const int abc_text_size_large_material = 2131099713;
+			
+			// aapt resource value: 0x7F060042
+			public const int abc_text_size_medium_material = 2131099714;
+			
+			// aapt resource value: 0x7F060043
+			public const int abc_text_size_menu_header_material = 2131099715;
+			
+			// aapt resource value: 0x7F060044
+			public const int abc_text_size_menu_material = 2131099716;
+			
+			// aapt resource value: 0x7F060045
+			public const int abc_text_size_small_material = 2131099717;
+			
+			// aapt resource value: 0x7F060046
+			public const int abc_text_size_subhead_material = 2131099718;
+			
+			// aapt resource value: 0x7F060047
+			public const int abc_text_size_subtitle_material_toolbar = 2131099719;
+			
+			// aapt resource value: 0x7F060048
+			public const int abc_text_size_title_material = 2131099720;
+			
+			// aapt resource value: 0x7F060049
+			public const int abc_text_size_title_material_toolbar = 2131099721;
+			
+			// aapt resource value: 0x7F06004A
+			public const int cardview_compat_inset_shadow = 2131099722;
+			
+			// aapt resource value: 0x7F06004B
+			public const int cardview_default_elevation = 2131099723;
+			
+			// aapt resource value: 0x7F06004C
+			public const int cardview_default_radius = 2131099724;
+			
+			// aapt resource value: 0x7F06004D
+			public const int design_appbar_elevation = 2131099725;
+			
+			// aapt resource value: 0x7F06004E
+			public const int design_bottom_navigation_active_item_max_width = 2131099726;
+			
+			// aapt resource value: 0x7F06004F
+			public const int design_bottom_navigation_active_text_size = 2131099727;
+			
+			// aapt resource value: 0x7F060050
+			public const int design_bottom_navigation_elevation = 2131099728;
+			
+			// aapt resource value: 0x7F060051
+			public const int design_bottom_navigation_height = 2131099729;
+			
+			// aapt resource value: 0x7F060052
+			public const int design_bottom_navigation_item_max_width = 2131099730;
+			
+			// aapt resource value: 0x7F060053
+			public const int design_bottom_navigation_item_min_width = 2131099731;
+			
+			// aapt resource value: 0x7F060054
+			public const int design_bottom_navigation_margin = 2131099732;
+			
+			// aapt resource value: 0x7F060055
+			public const int design_bottom_navigation_shadow_height = 2131099733;
+			
+			// aapt resource value: 0x7F060056
+			public const int design_bottom_navigation_text_size = 2131099734;
+			
+			// aapt resource value: 0x7F060057
+			public const int design_bottom_sheet_modal_elevation = 2131099735;
+			
+			// aapt resource value: 0x7F060058
+			public const int design_bottom_sheet_peek_height_min = 2131099736;
+			
+			// aapt resource value: 0x7F060059
+			public const int design_fab_border_width = 2131099737;
+			
+			// aapt resource value: 0x7F06005A
+			public const int design_fab_elevation = 2131099738;
+			
+			// aapt resource value: 0x7F06005B
+			public const int design_fab_image_size = 2131099739;
+			
+			// aapt resource value: 0x7F06005C
+			public const int design_fab_size_mini = 2131099740;
+			
+			// aapt resource value: 0x7F06005D
+			public const int design_fab_size_normal = 2131099741;
+			
+			// aapt resource value: 0x7F06005E
+			public const int design_fab_translation_z_pressed = 2131099742;
+			
+			// aapt resource value: 0x7F06005F
+			public const int design_navigation_elevation = 2131099743;
+			
+			// aapt resource value: 0x7F060060
+			public const int design_navigation_icon_padding = 2131099744;
+			
+			// aapt resource value: 0x7F060061
+			public const int design_navigation_icon_size = 2131099745;
+			
+			// aapt resource value: 0x7F060062
+			public const int design_navigation_max_width = 2131099746;
+			
+			// aapt resource value: 0x7F060063
+			public const int design_navigation_padding_bottom = 2131099747;
+			
+			// aapt resource value: 0x7F060064
+			public const int design_navigation_separator_vertical_padding = 2131099748;
+			
+			// aapt resource value: 0x7F060065
+			public const int design_snackbar_action_inline_max_width = 2131099749;
+			
+			// aapt resource value: 0x7F060066
+			public const int design_snackbar_background_corner_radius = 2131099750;
+			
+			// aapt resource value: 0x7F060067
+			public const int design_snackbar_elevation = 2131099751;
+			
+			// aapt resource value: 0x7F060068
+			public const int design_snackbar_extra_spacing_horizontal = 2131099752;
+			
+			// aapt resource value: 0x7F060069
+			public const int design_snackbar_max_width = 2131099753;
+			
+			// aapt resource value: 0x7F06006A
+			public const int design_snackbar_min_width = 2131099754;
+			
+			// aapt resource value: 0x7F06006B
+			public const int design_snackbar_padding_horizontal = 2131099755;
+			
+			// aapt resource value: 0x7F06006C
+			public const int design_snackbar_padding_vertical = 2131099756;
+			
+			// aapt resource value: 0x7F06006D
+			public const int design_snackbar_padding_vertical_2lines = 2131099757;
+			
+			// aapt resource value: 0x7F06006E
+			public const int design_snackbar_text_size = 2131099758;
+			
+			// aapt resource value: 0x7F06006F
+			public const int design_tab_max_width = 2131099759;
+			
+			// aapt resource value: 0x7F060070
+			public const int design_tab_scrollable_min_width = 2131099760;
+			
+			// aapt resource value: 0x7F060071
+			public const int design_tab_text_size = 2131099761;
+			
+			// aapt resource value: 0x7F060072
+			public const int design_tab_text_size_2line = 2131099762;
+			
+			// aapt resource value: 0x7F060073
+			public const int disabled_alpha_material_dark = 2131099763;
+			
+			// aapt resource value: 0x7F060074
+			public const int disabled_alpha_material_light = 2131099764;
+			
+			// aapt resource value: 0x7F060075
+			public const int highlight_alpha_material_colored = 2131099765;
+			
+			// aapt resource value: 0x7F060076
+			public const int highlight_alpha_material_dark = 2131099766;
+			
+			// aapt resource value: 0x7F060077
+			public const int highlight_alpha_material_light = 2131099767;
+			
+			// aapt resource value: 0x7F060078
+			public const int hint_alpha_material_dark = 2131099768;
+			
+			// aapt resource value: 0x7F060079
+			public const int hint_alpha_material_light = 2131099769;
+			
+			// aapt resource value: 0x7F06007A
+			public const int hint_pressed_alpha_material_dark = 2131099770;
+			
+			// aapt resource value: 0x7F06007B
+			public const int hint_pressed_alpha_material_light = 2131099771;
+			
+			// aapt resource value: 0x7F06007C
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099772;
+			
+			// aapt resource value: 0x7F06007D
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131099773;
+			
+			// aapt resource value: 0x7F06007E
+			public const int item_touch_helper_swipe_escape_velocity = 2131099774;
+			
+			// aapt resource value: 0x7F06007F
+			public const int mr_controller_volume_group_list_item_height = 2131099775;
+			
+			// aapt resource value: 0x7F060080
+			public const int mr_controller_volume_group_list_item_icon_size = 2131099776;
+			
+			// aapt resource value: 0x7F060081
+			public const int mr_controller_volume_group_list_max_height = 2131099777;
+			
+			// aapt resource value: 0x7F060082
+			public const int mr_controller_volume_group_list_padding_top = 2131099778;
+			
+			// aapt resource value: 0x7F060083
+			public const int mr_dialog_fixed_width_major = 2131099779;
+			
+			// aapt resource value: 0x7F060084
+			public const int mr_dialog_fixed_width_minor = 2131099780;
+			
+			// aapt resource value: 0x7F060085
+			public const int notification_action_icon_size = 2131099781;
+			
+			// aapt resource value: 0x7F060086
+			public const int notification_action_text_size = 2131099782;
+			
+			// aapt resource value: 0x7F060087
+			public const int notification_big_circle_margin = 2131099783;
+			
+			// aapt resource value: 0x7F060088
+			public const int notification_content_margin_start = 2131099784;
+			
+			// aapt resource value: 0x7F060089
+			public const int notification_large_icon_height = 2131099785;
+			
+			// aapt resource value: 0x7F06008A
+			public const int notification_large_icon_width = 2131099786;
+			
+			// aapt resource value: 0x7F06008B
+			public const int notification_main_column_padding_top = 2131099787;
+			
+			// aapt resource value: 0x7F06008C
+			public const int notification_media_narrow_margin = 2131099788;
+			
+			// aapt resource value: 0x7F06008D
+			public const int notification_right_icon_size = 2131099789;
+			
+			// aapt resource value: 0x7F06008E
+			public const int notification_right_side_padding_top = 2131099790;
+			
+			// aapt resource value: 0x7F06008F
+			public const int notification_small_icon_background_padding = 2131099791;
+			
+			// aapt resource value: 0x7F060090
+			public const int notification_small_icon_size_as_large = 2131099792;
+			
+			// aapt resource value: 0x7F060091
+			public const int notification_subtext_size = 2131099793;
+			
+			// aapt resource value: 0x7F060092
+			public const int notification_top_pad = 2131099794;
+			
+			// aapt resource value: 0x7F060093
+			public const int notification_top_pad_large_text = 2131099795;
+			
+			static Dimension()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Dimension()
+			{
+			}
+		}
+		
+		public partial class Drawable
+		{
+			
+			// aapt resource value: 0x7F070006
+			public const int abc_ab_share_pack_mtrl_alpha = 2131165190;
+			
+			// aapt resource value: 0x7F070007
+			public const int abc_action_bar_item_background_material = 2131165191;
+			
+			// aapt resource value: 0x7F070008
+			public const int abc_btn_borderless_material = 2131165192;
+			
+			// aapt resource value: 0x7F070009
+			public const int abc_btn_check_material = 2131165193;
+			
+			// aapt resource value: 0x7F07000A
+			public const int abc_btn_check_to_on_mtrl_000 = 2131165194;
+			
+			// aapt resource value: 0x7F07000B
+			public const int abc_btn_check_to_on_mtrl_015 = 2131165195;
+			
+			// aapt resource value: 0x7F07000C
+			public const int abc_btn_colored_material = 2131165196;
+			
+			// aapt resource value: 0x7F07000D
+			public const int abc_btn_default_mtrl_shape = 2131165197;
+			
+			// aapt resource value: 0x7F07000E
+			public const int abc_btn_radio_material = 2131165198;
+			
+			// aapt resource value: 0x7F07000F
+			public const int abc_btn_radio_to_on_mtrl_000 = 2131165199;
+			
+			// aapt resource value: 0x7F070010
+			public const int abc_btn_radio_to_on_mtrl_015 = 2131165200;
+			
+			// aapt resource value: 0x7F070011
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2131165201;
+			
+			// aapt resource value: 0x7F070012
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2131165202;
+			
+			// aapt resource value: 0x7F070013
+			public const int abc_cab_background_internal_bg = 2131165203;
+			
+			// aapt resource value: 0x7F070014
+			public const int abc_cab_background_top_material = 2131165204;
+			
+			// aapt resource value: 0x7F070015
+			public const int abc_cab_background_top_mtrl_alpha = 2131165205;
+			
+			// aapt resource value: 0x7F070016
+			public const int abc_control_background_material = 2131165206;
+			
+			// aapt resource value: 0x7F070017
+			public const int abc_dialog_material_background = 2131165207;
+			
+			// aapt resource value: 0x7F070018
+			public const int abc_edit_text_material = 2131165208;
+			
+			// aapt resource value: 0x7F070019
+			public const int abc_ic_ab_back_material = 2131165209;
+			
+			// aapt resource value: 0x7F07001A
+			public const int abc_ic_arrow_drop_right_black_24dp = 2131165210;
+			
+			// aapt resource value: 0x7F07001B
+			public const int abc_ic_clear_material = 2131165211;
+			
+			// aapt resource value: 0x7F07001C
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2131165212;
+			
+			// aapt resource value: 0x7F07001D
+			public const int abc_ic_go_search_api_material = 2131165213;
+			
+			// aapt resource value: 0x7F07001E
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2131165214;
+			
+			// aapt resource value: 0x7F07001F
+			public const int abc_ic_menu_cut_mtrl_alpha = 2131165215;
+			
+			// aapt resource value: 0x7F070020
+			public const int abc_ic_menu_overflow_material = 2131165216;
+			
+			// aapt resource value: 0x7F070021
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2131165217;
+			
+			// aapt resource value: 0x7F070022
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2131165218;
+			
+			// aapt resource value: 0x7F070023
+			public const int abc_ic_menu_share_mtrl_alpha = 2131165219;
+			
+			// aapt resource value: 0x7F070024
+			public const int abc_ic_search_api_material = 2131165220;
+			
+			// aapt resource value: 0x7F070025
+			public const int abc_ic_star_black_16dp = 2131165221;
+			
+			// aapt resource value: 0x7F070026
+			public const int abc_ic_star_black_36dp = 2131165222;
+			
+			// aapt resource value: 0x7F070027
+			public const int abc_ic_star_black_48dp = 2131165223;
+			
+			// aapt resource value: 0x7F070028
+			public const int abc_ic_star_half_black_16dp = 2131165224;
+			
+			// aapt resource value: 0x7F070029
+			public const int abc_ic_star_half_black_36dp = 2131165225;
+			
+			// aapt resource value: 0x7F07002A
+			public const int abc_ic_star_half_black_48dp = 2131165226;
+			
+			// aapt resource value: 0x7F07002B
+			public const int abc_ic_voice_search_api_material = 2131165227;
+			
+			// aapt resource value: 0x7F07002C
+			public const int abc_item_background_holo_dark = 2131165228;
+			
+			// aapt resource value: 0x7F07002D
+			public const int abc_item_background_holo_light = 2131165229;
+			
+			// aapt resource value: 0x7F07002E
+			public const int abc_list_divider_mtrl_alpha = 2131165230;
+			
+			// aapt resource value: 0x7F07002F
+			public const int abc_list_focused_holo = 2131165231;
+			
+			// aapt resource value: 0x7F070030
+			public const int abc_list_longpressed_holo = 2131165232;
+			
+			// aapt resource value: 0x7F070031
+			public const int abc_list_pressed_holo_dark = 2131165233;
+			
+			// aapt resource value: 0x7F070032
+			public const int abc_list_pressed_holo_light = 2131165234;
+			
+			// aapt resource value: 0x7F070033
+			public const int abc_list_selector_background_transition_holo_dark = 2131165235;
+			
+			// aapt resource value: 0x7F070034
+			public const int abc_list_selector_background_transition_holo_light = 2131165236;
+			
+			// aapt resource value: 0x7F070035
+			public const int abc_list_selector_disabled_holo_dark = 2131165237;
+			
+			// aapt resource value: 0x7F070036
+			public const int abc_list_selector_disabled_holo_light = 2131165238;
+			
+			// aapt resource value: 0x7F070037
+			public const int abc_list_selector_holo_dark = 2131165239;
+			
+			// aapt resource value: 0x7F070038
+			public const int abc_list_selector_holo_light = 2131165240;
+			
+			// aapt resource value: 0x7F070039
+			public const int abc_menu_hardkey_panel_mtrl_mult = 2131165241;
+			
+			// aapt resource value: 0x7F07003A
+			public const int abc_popup_background_mtrl_mult = 2131165242;
+			
+			// aapt resource value: 0x7F07003B
+			public const int abc_ratingbar_indicator_material = 2131165243;
+			
+			// aapt resource value: 0x7F07003C
+			public const int abc_ratingbar_material = 2131165244;
+			
+			// aapt resource value: 0x7F07003D
+			public const int abc_ratingbar_small_material = 2131165245;
+			
+			// aapt resource value: 0x7F07003E
+			public const int abc_scrubber_control_off_mtrl_alpha = 2131165246;
+			
+			// aapt resource value: 0x7F07003F
+			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2131165247;
+			
+			// aapt resource value: 0x7F070040
+			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2131165248;
+			
+			// aapt resource value: 0x7F070041
+			public const int abc_scrubber_primary_mtrl_alpha = 2131165249;
+			
+			// aapt resource value: 0x7F070042
+			public const int abc_scrubber_track_mtrl_alpha = 2131165250;
+			
+			// aapt resource value: 0x7F070043
+			public const int abc_seekbar_thumb_material = 2131165251;
+			
+			// aapt resource value: 0x7F070044
+			public const int abc_seekbar_tick_mark_material = 2131165252;
+			
+			// aapt resource value: 0x7F070045
+			public const int abc_seekbar_track_material = 2131165253;
+			
+			// aapt resource value: 0x7F070046
+			public const int abc_spinner_mtrl_am_alpha = 2131165254;
+			
+			// aapt resource value: 0x7F070047
+			public const int abc_spinner_textfield_background_material = 2131165255;
+			
+			// aapt resource value: 0x7F070048
+			public const int abc_switch_thumb_material = 2131165256;
+			
+			// aapt resource value: 0x7F070049
+			public const int abc_switch_track_mtrl_alpha = 2131165257;
+			
+			// aapt resource value: 0x7F07004A
+			public const int abc_tab_indicator_material = 2131165258;
+			
+			// aapt resource value: 0x7F07004B
+			public const int abc_tab_indicator_mtrl_alpha = 2131165259;
+			
+			// aapt resource value: 0x7F070053
+			public const int abc_textfield_activated_mtrl_alpha = 2131165267;
+			
+			// aapt resource value: 0x7F070054
+			public const int abc_textfield_default_mtrl_alpha = 2131165268;
+			
+			// aapt resource value: 0x7F070055
+			public const int abc_textfield_search_activated_mtrl_alpha = 2131165269;
+			
+			// aapt resource value: 0x7F070056
+			public const int abc_textfield_search_default_mtrl_alpha = 2131165270;
+			
+			// aapt resource value: 0x7F070057
+			public const int abc_textfield_search_material = 2131165271;
+			
+			// aapt resource value: 0x7F07004C
+			public const int abc_text_cursor_material = 2131165260;
+			
+			// aapt resource value: 0x7F07004D
+			public const int abc_text_select_handle_left_mtrl_dark = 2131165261;
+			
+			// aapt resource value: 0x7F07004E
+			public const int abc_text_select_handle_left_mtrl_light = 2131165262;
+			
+			// aapt resource value: 0x7F07004F
+			public const int abc_text_select_handle_middle_mtrl_dark = 2131165263;
+			
+			// aapt resource value: 0x7F070050
+			public const int abc_text_select_handle_middle_mtrl_light = 2131165264;
+			
+			// aapt resource value: 0x7F070051
+			public const int abc_text_select_handle_right_mtrl_dark = 2131165265;
+			
+			// aapt resource value: 0x7F070052
+			public const int abc_text_select_handle_right_mtrl_light = 2131165266;
+			
+			// aapt resource value: 0x7F070058
+			public const int abc_vector_test = 2131165272;
+			
+			// aapt resource value: 0x7F070059
+			public const int avd_hide_password = 2131165273;
+			
+			// aapt resource value: 0x7F07005A
+			public const int avd_show_password = 2131165274;
+			
+			// aapt resource value: 0x7F07005B
+			public const int design_bottom_navigation_item_background = 2131165275;
+			
+			// aapt resource value: 0x7F07005C
+			public const int design_fab_background = 2131165276;
+			
+			// aapt resource value: 0x7F07005D
+			public const int design_ic_visibility = 2131165277;
+			
+			// aapt resource value: 0x7F07005E
+			public const int design_ic_visibility_off = 2131165278;
+			
+			// aapt resource value: 0x7F07005F
+			public const int design_password_eye = 2131165279;
+			
+			// aapt resource value: 0x7F070060
+			public const int design_snackbar_background = 2131165280;
+			
+			// aapt resource value: 0x7F070061
+			public const int ic_audiotrack_dark = 2131165281;
+			
+			// aapt resource value: 0x7F070062
+			public const int ic_audiotrack_light = 2131165282;
+			
+			// aapt resource value: 0x7F070063
+			public const int ic_dialog_close_dark = 2131165283;
+			
+			// aapt resource value: 0x7F070064
+			public const int ic_dialog_close_light = 2131165284;
+			
+			// aapt resource value: 0x7F070065
+			public const int ic_group_collapse_00 = 2131165285;
+			
+			// aapt resource value: 0x7F070066
+			public const int ic_group_collapse_01 = 2131165286;
+			
+			// aapt resource value: 0x7F070067
+			public const int ic_group_collapse_02 = 2131165287;
+			
+			// aapt resource value: 0x7F070068
+			public const int ic_group_collapse_03 = 2131165288;
+			
+			// aapt resource value: 0x7F070069
+			public const int ic_group_collapse_04 = 2131165289;
+			
+			// aapt resource value: 0x7F07006A
+			public const int ic_group_collapse_05 = 2131165290;
+			
+			// aapt resource value: 0x7F07006B
+			public const int ic_group_collapse_06 = 2131165291;
+			
+			// aapt resource value: 0x7F07006C
+			public const int ic_group_collapse_07 = 2131165292;
+			
+			// aapt resource value: 0x7F07006D
+			public const int ic_group_collapse_08 = 2131165293;
+			
+			// aapt resource value: 0x7F07006E
+			public const int ic_group_collapse_09 = 2131165294;
+			
+			// aapt resource value: 0x7F07006F
+			public const int ic_group_collapse_10 = 2131165295;
+			
+			// aapt resource value: 0x7F070070
+			public const int ic_group_collapse_11 = 2131165296;
+			
+			// aapt resource value: 0x7F070071
+			public const int ic_group_collapse_12 = 2131165297;
+			
+			// aapt resource value: 0x7F070072
+			public const int ic_group_collapse_13 = 2131165298;
+			
+			// aapt resource value: 0x7F070073
+			public const int ic_group_collapse_14 = 2131165299;
+			
+			// aapt resource value: 0x7F070074
+			public const int ic_group_collapse_15 = 2131165300;
+			
+			// aapt resource value: 0x7F070075
+			public const int ic_group_expand_00 = 2131165301;
+			
+			// aapt resource value: 0x7F070076
+			public const int ic_group_expand_01 = 2131165302;
+			
+			// aapt resource value: 0x7F070077
+			public const int ic_group_expand_02 = 2131165303;
+			
+			// aapt resource value: 0x7F070078
+			public const int ic_group_expand_03 = 2131165304;
+			
+			// aapt resource value: 0x7F070079
+			public const int ic_group_expand_04 = 2131165305;
+			
+			// aapt resource value: 0x7F07007A
+			public const int ic_group_expand_05 = 2131165306;
+			
+			// aapt resource value: 0x7F07007B
+			public const int ic_group_expand_06 = 2131165307;
+			
+			// aapt resource value: 0x7F07007C
+			public const int ic_group_expand_07 = 2131165308;
+			
+			// aapt resource value: 0x7F07007D
+			public const int ic_group_expand_08 = 2131165309;
+			
+			// aapt resource value: 0x7F07007E
+			public const int ic_group_expand_09 = 2131165310;
+			
+			// aapt resource value: 0x7F07007F
+			public const int ic_group_expand_10 = 2131165311;
+			
+			// aapt resource value: 0x7F070080
+			public const int ic_group_expand_11 = 2131165312;
+			
+			// aapt resource value: 0x7F070081
+			public const int ic_group_expand_12 = 2131165313;
+			
+			// aapt resource value: 0x7F070082
+			public const int ic_group_expand_13 = 2131165314;
+			
+			// aapt resource value: 0x7F070083
+			public const int ic_group_expand_14 = 2131165315;
+			
+			// aapt resource value: 0x7F070084
+			public const int ic_group_expand_15 = 2131165316;
+			
+			// aapt resource value: 0x7F070085
+			public const int ic_media_pause_dark = 2131165317;
+			
+			// aapt resource value: 0x7F070086
+			public const int ic_media_pause_light = 2131165318;
+			
+			// aapt resource value: 0x7F070087
+			public const int ic_media_play_dark = 2131165319;
+			
+			// aapt resource value: 0x7F070088
+			public const int ic_media_play_light = 2131165320;
+			
+			// aapt resource value: 0x7F070089
+			public const int ic_media_stop_dark = 2131165321;
+			
+			// aapt resource value: 0x7F07008A
+			public const int ic_media_stop_light = 2131165322;
+			
+			// aapt resource value: 0x7F07008B
+			public const int ic_mr_button_connected_00_dark = 2131165323;
+			
+			// aapt resource value: 0x7F07008C
+			public const int ic_mr_button_connected_00_light = 2131165324;
+			
+			// aapt resource value: 0x7F07008D
+			public const int ic_mr_button_connected_01_dark = 2131165325;
+			
+			// aapt resource value: 0x7F07008E
+			public const int ic_mr_button_connected_01_light = 2131165326;
+			
+			// aapt resource value: 0x7F07008F
+			public const int ic_mr_button_connected_02_dark = 2131165327;
+			
+			// aapt resource value: 0x7F070090
+			public const int ic_mr_button_connected_02_light = 2131165328;
+			
+			// aapt resource value: 0x7F070091
+			public const int ic_mr_button_connected_03_dark = 2131165329;
+			
+			// aapt resource value: 0x7F070092
+			public const int ic_mr_button_connected_03_light = 2131165330;
+			
+			// aapt resource value: 0x7F070093
+			public const int ic_mr_button_connected_04_dark = 2131165331;
+			
+			// aapt resource value: 0x7F070094
+			public const int ic_mr_button_connected_04_light = 2131165332;
+			
+			// aapt resource value: 0x7F070095
+			public const int ic_mr_button_connected_05_dark = 2131165333;
+			
+			// aapt resource value: 0x7F070096
+			public const int ic_mr_button_connected_05_light = 2131165334;
+			
+			// aapt resource value: 0x7F070097
+			public const int ic_mr_button_connected_06_dark = 2131165335;
+			
+			// aapt resource value: 0x7F070098
+			public const int ic_mr_button_connected_06_light = 2131165336;
+			
+			// aapt resource value: 0x7F070099
+			public const int ic_mr_button_connected_07_dark = 2131165337;
+			
+			// aapt resource value: 0x7F07009A
+			public const int ic_mr_button_connected_07_light = 2131165338;
+			
+			// aapt resource value: 0x7F07009B
+			public const int ic_mr_button_connected_08_dark = 2131165339;
+			
+			// aapt resource value: 0x7F07009C
+			public const int ic_mr_button_connected_08_light = 2131165340;
+			
+			// aapt resource value: 0x7F07009D
+			public const int ic_mr_button_connected_09_dark = 2131165341;
+			
+			// aapt resource value: 0x7F07009E
+			public const int ic_mr_button_connected_09_light = 2131165342;
+			
+			// aapt resource value: 0x7F07009F
+			public const int ic_mr_button_connected_10_dark = 2131165343;
+			
+			// aapt resource value: 0x7F0700A0
+			public const int ic_mr_button_connected_10_light = 2131165344;
+			
+			// aapt resource value: 0x7F0700A1
+			public const int ic_mr_button_connected_11_dark = 2131165345;
+			
+			// aapt resource value: 0x7F0700A2
+			public const int ic_mr_button_connected_11_light = 2131165346;
+			
+			// aapt resource value: 0x7F0700A3
+			public const int ic_mr_button_connected_12_dark = 2131165347;
+			
+			// aapt resource value: 0x7F0700A4
+			public const int ic_mr_button_connected_12_light = 2131165348;
+			
+			// aapt resource value: 0x7F0700A5
+			public const int ic_mr_button_connected_13_dark = 2131165349;
+			
+			// aapt resource value: 0x7F0700A6
+			public const int ic_mr_button_connected_13_light = 2131165350;
+			
+			// aapt resource value: 0x7F0700A7
+			public const int ic_mr_button_connected_14_dark = 2131165351;
+			
+			// aapt resource value: 0x7F0700A8
+			public const int ic_mr_button_connected_14_light = 2131165352;
+			
+			// aapt resource value: 0x7F0700A9
+			public const int ic_mr_button_connected_15_dark = 2131165353;
+			
+			// aapt resource value: 0x7F0700AA
+			public const int ic_mr_button_connected_15_light = 2131165354;
+			
+			// aapt resource value: 0x7F0700AB
+			public const int ic_mr_button_connected_16_dark = 2131165355;
+			
+			// aapt resource value: 0x7F0700AC
+			public const int ic_mr_button_connected_16_light = 2131165356;
+			
+			// aapt resource value: 0x7F0700AD
+			public const int ic_mr_button_connected_17_dark = 2131165357;
+			
+			// aapt resource value: 0x7F0700AE
+			public const int ic_mr_button_connected_17_light = 2131165358;
+			
+			// aapt resource value: 0x7F0700AF
+			public const int ic_mr_button_connected_18_dark = 2131165359;
+			
+			// aapt resource value: 0x7F0700B0
+			public const int ic_mr_button_connected_18_light = 2131165360;
+			
+			// aapt resource value: 0x7F0700B1
+			public const int ic_mr_button_connected_19_dark = 2131165361;
+			
+			// aapt resource value: 0x7F0700B2
+			public const int ic_mr_button_connected_19_light = 2131165362;
+			
+			// aapt resource value: 0x7F0700B3
+			public const int ic_mr_button_connected_20_dark = 2131165363;
+			
+			// aapt resource value: 0x7F0700B4
+			public const int ic_mr_button_connected_20_light = 2131165364;
+			
+			// aapt resource value: 0x7F0700B5
+			public const int ic_mr_button_connected_21_dark = 2131165365;
+			
+			// aapt resource value: 0x7F0700B6
+			public const int ic_mr_button_connected_21_light = 2131165366;
+			
+			// aapt resource value: 0x7F0700B7
+			public const int ic_mr_button_connected_22_dark = 2131165367;
+			
+			// aapt resource value: 0x7F0700B8
+			public const int ic_mr_button_connected_22_light = 2131165368;
+			
+			// aapt resource value: 0x7F0700B9
+			public const int ic_mr_button_connecting_00_dark = 2131165369;
+			
+			// aapt resource value: 0x7F0700BA
+			public const int ic_mr_button_connecting_00_light = 2131165370;
+			
+			// aapt resource value: 0x7F0700BB
+			public const int ic_mr_button_connecting_01_dark = 2131165371;
+			
+			// aapt resource value: 0x7F0700BC
+			public const int ic_mr_button_connecting_01_light = 2131165372;
+			
+			// aapt resource value: 0x7F0700BD
+			public const int ic_mr_button_connecting_02_dark = 2131165373;
+			
+			// aapt resource value: 0x7F0700BE
+			public const int ic_mr_button_connecting_02_light = 2131165374;
+			
+			// aapt resource value: 0x7F0700BF
+			public const int ic_mr_button_connecting_03_dark = 2131165375;
+			
+			// aapt resource value: 0x7F0700C0
+			public const int ic_mr_button_connecting_03_light = 2131165376;
+			
+			// aapt resource value: 0x7F0700C1
+			public const int ic_mr_button_connecting_04_dark = 2131165377;
+			
+			// aapt resource value: 0x7F0700C2
+			public const int ic_mr_button_connecting_04_light = 2131165378;
+			
+			// aapt resource value: 0x7F0700C3
+			public const int ic_mr_button_connecting_05_dark = 2131165379;
+			
+			// aapt resource value: 0x7F0700C4
+			public const int ic_mr_button_connecting_05_light = 2131165380;
+			
+			// aapt resource value: 0x7F0700C5
+			public const int ic_mr_button_connecting_06_dark = 2131165381;
+			
+			// aapt resource value: 0x7F0700C6
+			public const int ic_mr_button_connecting_06_light = 2131165382;
+			
+			// aapt resource value: 0x7F0700C7
+			public const int ic_mr_button_connecting_07_dark = 2131165383;
+			
+			// aapt resource value: 0x7F0700C8
+			public const int ic_mr_button_connecting_07_light = 2131165384;
+			
+			// aapt resource value: 0x7F0700C9
+			public const int ic_mr_button_connecting_08_dark = 2131165385;
+			
+			// aapt resource value: 0x7F0700CA
+			public const int ic_mr_button_connecting_08_light = 2131165386;
+			
+			// aapt resource value: 0x7F0700CB
+			public const int ic_mr_button_connecting_09_dark = 2131165387;
+			
+			// aapt resource value: 0x7F0700CC
+			public const int ic_mr_button_connecting_09_light = 2131165388;
+			
+			// aapt resource value: 0x7F0700CD
+			public const int ic_mr_button_connecting_10_dark = 2131165389;
+			
+			// aapt resource value: 0x7F0700CE
+			public const int ic_mr_button_connecting_10_light = 2131165390;
+			
+			// aapt resource value: 0x7F0700CF
+			public const int ic_mr_button_connecting_11_dark = 2131165391;
+			
+			// aapt resource value: 0x7F0700D0
+			public const int ic_mr_button_connecting_11_light = 2131165392;
+			
+			// aapt resource value: 0x7F0700D1
+			public const int ic_mr_button_connecting_12_dark = 2131165393;
+			
+			// aapt resource value: 0x7F0700D2
+			public const int ic_mr_button_connecting_12_light = 2131165394;
+			
+			// aapt resource value: 0x7F0700D3
+			public const int ic_mr_button_connecting_13_dark = 2131165395;
+			
+			// aapt resource value: 0x7F0700D4
+			public const int ic_mr_button_connecting_13_light = 2131165396;
+			
+			// aapt resource value: 0x7F0700D5
+			public const int ic_mr_button_connecting_14_dark = 2131165397;
+			
+			// aapt resource value: 0x7F0700D6
+			public const int ic_mr_button_connecting_14_light = 2131165398;
+			
+			// aapt resource value: 0x7F0700D7
+			public const int ic_mr_button_connecting_15_dark = 2131165399;
+			
+			// aapt resource value: 0x7F0700D8
+			public const int ic_mr_button_connecting_15_light = 2131165400;
+			
+			// aapt resource value: 0x7F0700D9
+			public const int ic_mr_button_connecting_16_dark = 2131165401;
+			
+			// aapt resource value: 0x7F0700DA
+			public const int ic_mr_button_connecting_16_light = 2131165402;
+			
+			// aapt resource value: 0x7F0700DB
+			public const int ic_mr_button_connecting_17_dark = 2131165403;
+			
+			// aapt resource value: 0x7F0700DC
+			public const int ic_mr_button_connecting_17_light = 2131165404;
+			
+			// aapt resource value: 0x7F0700DD
+			public const int ic_mr_button_connecting_18_dark = 2131165405;
+			
+			// aapt resource value: 0x7F0700DE
+			public const int ic_mr_button_connecting_18_light = 2131165406;
+			
+			// aapt resource value: 0x7F0700DF
+			public const int ic_mr_button_connecting_19_dark = 2131165407;
+			
+			// aapt resource value: 0x7F0700E0
+			public const int ic_mr_button_connecting_19_light = 2131165408;
+			
+			// aapt resource value: 0x7F0700E1
+			public const int ic_mr_button_connecting_20_dark = 2131165409;
+			
+			// aapt resource value: 0x7F0700E2
+			public const int ic_mr_button_connecting_20_light = 2131165410;
+			
+			// aapt resource value: 0x7F0700E3
+			public const int ic_mr_button_connecting_21_dark = 2131165411;
+			
+			// aapt resource value: 0x7F0700E4
+			public const int ic_mr_button_connecting_21_light = 2131165412;
+			
+			// aapt resource value: 0x7F0700E5
+			public const int ic_mr_button_connecting_22_dark = 2131165413;
+			
+			// aapt resource value: 0x7F0700E6
+			public const int ic_mr_button_connecting_22_light = 2131165414;
+			
+			// aapt resource value: 0x7F0700E7
+			public const int ic_mr_button_disabled_dark = 2131165415;
+			
+			// aapt resource value: 0x7F0700E8
+			public const int ic_mr_button_disabled_light = 2131165416;
+			
+			// aapt resource value: 0x7F0700E9
+			public const int ic_mr_button_disconnected_dark = 2131165417;
+			
+			// aapt resource value: 0x7F0700EA
+			public const int ic_mr_button_disconnected_light = 2131165418;
+			
+			// aapt resource value: 0x7F0700EB
+			public const int ic_mr_button_grey = 2131165419;
+			
+			// aapt resource value: 0x7F0700EC
+			public const int ic_vol_type_speaker_dark = 2131165420;
+			
+			// aapt resource value: 0x7F0700ED
+			public const int ic_vol_type_speaker_group_dark = 2131165421;
+			
+			// aapt resource value: 0x7F0700EE
+			public const int ic_vol_type_speaker_group_light = 2131165422;
+			
+			// aapt resource value: 0x7F0700EF
+			public const int ic_vol_type_speaker_light = 2131165423;
+			
+			// aapt resource value: 0x7F0700F0
+			public const int ic_vol_type_tv_dark = 2131165424;
+			
+			// aapt resource value: 0x7F0700F1
+			public const int ic_vol_type_tv_light = 2131165425;
+			
+			// aapt resource value: 0x7F0700F2
+			public const int mr_button_connected_dark = 2131165426;
+			
+			// aapt resource value: 0x7F0700F3
+			public const int mr_button_connected_light = 2131165427;
+			
+			// aapt resource value: 0x7F0700F4
+			public const int mr_button_connecting_dark = 2131165428;
+			
+			// aapt resource value: 0x7F0700F5
+			public const int mr_button_connecting_light = 2131165429;
+			
+			// aapt resource value: 0x7F0700F6
+			public const int mr_button_dark = 2131165430;
+			
+			// aapt resource value: 0x7F0700F7
+			public const int mr_button_light = 2131165431;
+			
+			// aapt resource value: 0x7F0700F8
+			public const int mr_dialog_close_dark = 2131165432;
+			
+			// aapt resource value: 0x7F0700F9
+			public const int mr_dialog_close_light = 2131165433;
+			
+			// aapt resource value: 0x7F0700FA
+			public const int mr_dialog_material_background_dark = 2131165434;
+			
+			// aapt resource value: 0x7F0700FB
+			public const int mr_dialog_material_background_light = 2131165435;
+			
+			// aapt resource value: 0x7F0700FC
+			public const int mr_group_collapse = 2131165436;
+			
+			// aapt resource value: 0x7F0700FD
+			public const int mr_group_expand = 2131165437;
+			
+			// aapt resource value: 0x7F0700FE
+			public const int mr_media_pause_dark = 2131165438;
+			
+			// aapt resource value: 0x7F0700FF
+			public const int mr_media_pause_light = 2131165439;
+			
+			// aapt resource value: 0x7F070100
+			public const int mr_media_play_dark = 2131165440;
+			
+			// aapt resource value: 0x7F070101
+			public const int mr_media_play_light = 2131165441;
+			
+			// aapt resource value: 0x7F070102
+			public const int mr_media_stop_dark = 2131165442;
+			
+			// aapt resource value: 0x7F070103
+			public const int mr_media_stop_light = 2131165443;
+			
+			// aapt resource value: 0x7F070104
+			public const int mr_vol_type_audiotrack_dark = 2131165444;
+			
+			// aapt resource value: 0x7F070105
+			public const int mr_vol_type_audiotrack_light = 2131165445;
+			
+			// aapt resource value: 0x7F070106
+			public const int navigation_empty_icon = 2131165446;
+			
+			// aapt resource value: 0x7F070107
+			public const int notification_action_background = 2131165447;
+			
+			// aapt resource value: 0x7F070108
+			public const int notification_bg = 2131165448;
+			
+			// aapt resource value: 0x7F070109
+			public const int notification_bg_low = 2131165449;
+			
+			// aapt resource value: 0x7F07010A
+			public const int notification_bg_low_normal = 2131165450;
+			
+			// aapt resource value: 0x7F07010B
+			public const int notification_bg_low_pressed = 2131165451;
+			
+			// aapt resource value: 0x7F07010C
+			public const int notification_bg_normal = 2131165452;
+			
+			// aapt resource value: 0x7F07010D
+			public const int notification_bg_normal_pressed = 2131165453;
+			
+			// aapt resource value: 0x7F07010E
+			public const int notification_icon_background = 2131165454;
+			
+			// aapt resource value: 0x7F07010F
+			public const int notification_template_icon_bg = 2131165455;
+			
+			// aapt resource value: 0x7F070110
+			public const int notification_template_icon_low_bg = 2131165456;
+			
+			// aapt resource value: 0x7F070111
+			public const int notification_tile_bg = 2131165457;
+			
+			// aapt resource value: 0x7F070112
+			public const int notify_panel_notification_icon_bg = 2131165458;
+			
+			static Drawable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Drawable()
+			{
+			}
+		}
+		
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7F020000
-			public const int sliding_tabs = 2130837504;
+			// aapt resource value: 0x7F080000
+			public const int action0 = 2131230720;
 			
-			// aapt resource value: 0x7F020001
-			public const int toolbar = 2130837505;
+			// aapt resource value: 0x7F080012
+			public const int actions = 2131230738;
+			
+			// aapt resource value: 0x7F080001
+			public const int action_bar = 2131230721;
+			
+			// aapt resource value: 0x7F080002
+			public const int action_bar_activity_content = 2131230722;
+			
+			// aapt resource value: 0x7F080003
+			public const int action_bar_container = 2131230723;
+			
+			// aapt resource value: 0x7F080004
+			public const int action_bar_root = 2131230724;
+			
+			// aapt resource value: 0x7F080005
+			public const int action_bar_spinner = 2131230725;
+			
+			// aapt resource value: 0x7F080006
+			public const int action_bar_subtitle = 2131230726;
+			
+			// aapt resource value: 0x7F080007
+			public const int action_bar_title = 2131230727;
+			
+			// aapt resource value: 0x7F080008
+			public const int action_container = 2131230728;
+			
+			// aapt resource value: 0x7F080009
+			public const int action_context_bar = 2131230729;
+			
+			// aapt resource value: 0x7F08000A
+			public const int action_divider = 2131230730;
+			
+			// aapt resource value: 0x7F08000B
+			public const int action_image = 2131230731;
+			
+			// aapt resource value: 0x7F08000C
+			public const int action_menu_divider = 2131230732;
+			
+			// aapt resource value: 0x7F08000D
+			public const int action_menu_presenter = 2131230733;
+			
+			// aapt resource value: 0x7F08000E
+			public const int action_mode_bar = 2131230734;
+			
+			// aapt resource value: 0x7F08000F
+			public const int action_mode_bar_stub = 2131230735;
+			
+			// aapt resource value: 0x7F080010
+			public const int action_mode_close_button = 2131230736;
+			
+			// aapt resource value: 0x7F080011
+			public const int action_text = 2131230737;
+			
+			// aapt resource value: 0x7F080013
+			public const int activity_chooser_view_content = 2131230739;
+			
+			// aapt resource value: 0x7F080014
+			public const int add = 2131230740;
+			
+			// aapt resource value: 0x7F080015
+			public const int alertTitle = 2131230741;
+			
+			// aapt resource value: 0x7F080016
+			public const int all = 2131230742;
+			
+			// aapt resource value: 0x7F080017
+			public const int always = 2131230743;
+			
+			// aapt resource value: 0x7F080018
+			public const int auto = 2131230744;
+			
+			// aapt resource value: 0x7F080019
+			public const int beginning = 2131230745;
+			
+			// aapt resource value: 0x7F08001A
+			public const int bottom = 2131230746;
+			
+			// aapt resource value: 0x7F08001B
+			public const int buttonPanel = 2131230747;
+			
+			// aapt resource value: 0x7F08001C
+			public const int cancel_action = 2131230748;
+			
+			// aapt resource value: 0x7F08001D
+			public const int center = 2131230749;
+			
+			// aapt resource value: 0x7F08001E
+			public const int center_horizontal = 2131230750;
+			
+			// aapt resource value: 0x7F08001F
+			public const int center_vertical = 2131230751;
+			
+			// aapt resource value: 0x7F080020
+			public const int checkbox = 2131230752;
+			
+			// aapt resource value: 0x7F080021
+			public const int chronometer = 2131230753;
+			
+			// aapt resource value: 0x7F080022
+			public const int clip_horizontal = 2131230754;
+			
+			// aapt resource value: 0x7F080023
+			public const int clip_vertical = 2131230755;
+			
+			// aapt resource value: 0x7F080024
+			public const int collapseActionView = 2131230756;
+			
+			// aapt resource value: 0x7F080025
+			public const int container = 2131230757;
+			
+			// aapt resource value: 0x7F080026
+			public const int contentPanel = 2131230758;
+			
+			// aapt resource value: 0x7F080027
+			public const int coordinator = 2131230759;
+			
+			// aapt resource value: 0x7F080028
+			public const int custom = 2131230760;
+			
+			// aapt resource value: 0x7F080029
+			public const int customPanel = 2131230761;
+			
+			// aapt resource value: 0x7F08002A
+			public const int decor_content_parent = 2131230762;
+			
+			// aapt resource value: 0x7F08002B
+			public const int default_activity_button = 2131230763;
+			
+			// aapt resource value: 0x7F08002C
+			public const int design_bottom_sheet = 2131230764;
+			
+			// aapt resource value: 0x7F08002D
+			public const int design_menu_item_action_area = 2131230765;
+			
+			// aapt resource value: 0x7F08002E
+			public const int design_menu_item_action_area_stub = 2131230766;
+			
+			// aapt resource value: 0x7F08002F
+			public const int design_menu_item_text = 2131230767;
+			
+			// aapt resource value: 0x7F080030
+			public const int design_navigation_view = 2131230768;
+			
+			// aapt resource value: 0x7F080031
+			public const int disableHome = 2131230769;
+			
+			// aapt resource value: 0x7F080032
+			public const int edit_query = 2131230770;
+			
+			// aapt resource value: 0x7F080033
+			public const int end = 2131230771;
+			
+			// aapt resource value: 0x7F080034
+			public const int end_padder = 2131230772;
+			
+			// aapt resource value: 0x7F080035
+			public const int enterAlways = 2131230773;
+			
+			// aapt resource value: 0x7F080036
+			public const int enterAlwaysCollapsed = 2131230774;
+			
+			// aapt resource value: 0x7F080037
+			public const int exitUntilCollapsed = 2131230775;
+			
+			// aapt resource value: 0x7F080039
+			public const int expanded_menu = 2131230777;
+			
+			// aapt resource value: 0x7F080038
+			public const int expand_activities_button = 2131230776;
+			
+			// aapt resource value: 0x7F08003A
+			public const int fill = 2131230778;
+			
+			// aapt resource value: 0x7F08003B
+			public const int fill_horizontal = 2131230779;
+			
+			// aapt resource value: 0x7F08003C
+			public const int fill_vertical = 2131230780;
+			
+			// aapt resource value: 0x7F08003D
+			public const int @fixed = 2131230781;
+			
+			// aapt resource value: 0x7F08003E
+			public const int home = 2131230782;
+			
+			// aapt resource value: 0x7F08003F
+			public const int homeAsUp = 2131230783;
+			
+			// aapt resource value: 0x7F080040
+			public const int icon = 2131230784;
+			
+			// aapt resource value: 0x7F080041
+			public const int icon_group = 2131230785;
+			
+			// aapt resource value: 0x7F080042
+			public const int ifRoom = 2131230786;
+			
+			// aapt resource value: 0x7F080043
+			public const int image = 2131230787;
+			
+			// aapt resource value: 0x7F080044
+			public const int info = 2131230788;
+			
+			// aapt resource value: 0x7F080045
+			public const int item_touch_helper_previous_elevation = 2131230789;
+			
+			// aapt resource value: 0x7F080046
+			public const int largeLabel = 2131230790;
+			
+			// aapt resource value: 0x7F080047
+			public const int left = 2131230791;
+			
+			// aapt resource value: 0x7F080048
+			public const int line1 = 2131230792;
+			
+			// aapt resource value: 0x7F080049
+			public const int line3 = 2131230793;
+			
+			// aapt resource value: 0x7F08004A
+			public const int listMode = 2131230794;
+			
+			// aapt resource value: 0x7F08004B
+			public const int list_item = 2131230795;
+			
+			// aapt resource value: 0x7F08004C
+			public const int masked = 2131230796;
+			
+			// aapt resource value: 0x7F08004D
+			public const int media_actions = 2131230797;
+			
+			// aapt resource value: 0x7F08004E
+			public const int middle = 2131230798;
+			
+			// aapt resource value: 0x7F08004F
+			public const int mini = 2131230799;
+			
+			// aapt resource value: 0x7F080050
+			public const int mr_art = 2131230800;
+			
+			// aapt resource value: 0x7F080051
+			public const int mr_chooser_list = 2131230801;
+			
+			// aapt resource value: 0x7F080052
+			public const int mr_chooser_route_desc = 2131230802;
+			
+			// aapt resource value: 0x7F080053
+			public const int mr_chooser_route_icon = 2131230803;
+			
+			// aapt resource value: 0x7F080054
+			public const int mr_chooser_route_name = 2131230804;
+			
+			// aapt resource value: 0x7F080055
+			public const int mr_chooser_title = 2131230805;
+			
+			// aapt resource value: 0x7F080056
+			public const int mr_close = 2131230806;
+			
+			// aapt resource value: 0x7F080057
+			public const int mr_control_divider = 2131230807;
+			
+			// aapt resource value: 0x7F080058
+			public const int mr_control_playback_ctrl = 2131230808;
+			
+			// aapt resource value: 0x7F080059
+			public const int mr_control_subtitle = 2131230809;
+			
+			// aapt resource value: 0x7F08005A
+			public const int mr_control_title = 2131230810;
+			
+			// aapt resource value: 0x7F08005B
+			public const int mr_control_title_container = 2131230811;
+			
+			// aapt resource value: 0x7F08005C
+			public const int mr_custom_control = 2131230812;
+			
+			// aapt resource value: 0x7F08005D
+			public const int mr_default_control = 2131230813;
+			
+			// aapt resource value: 0x7F08005E
+			public const int mr_dialog_area = 2131230814;
+			
+			// aapt resource value: 0x7F08005F
+			public const int mr_expandable_area = 2131230815;
+			
+			// aapt resource value: 0x7F080060
+			public const int mr_group_expand_collapse = 2131230816;
+			
+			// aapt resource value: 0x7F080061
+			public const int mr_media_main_control = 2131230817;
+			
+			// aapt resource value: 0x7F080062
+			public const int mr_name = 2131230818;
+			
+			// aapt resource value: 0x7F080063
+			public const int mr_playback_control = 2131230819;
+			
+			// aapt resource value: 0x7F080064
+			public const int mr_title_bar = 2131230820;
+			
+			// aapt resource value: 0x7F080065
+			public const int mr_volume_control = 2131230821;
+			
+			// aapt resource value: 0x7F080066
+			public const int mr_volume_group_list = 2131230822;
+			
+			// aapt resource value: 0x7F080067
+			public const int mr_volume_item_icon = 2131230823;
+			
+			// aapt resource value: 0x7F080068
+			public const int mr_volume_slider = 2131230824;
+			
+			// aapt resource value: 0x7F080069
+			public const int multiply = 2131230825;
+			
+			// aapt resource value: 0x7F08006A
+			public const int navigation_header_container = 2131230826;
+			
+			// aapt resource value: 0x7F08006B
+			public const int never = 2131230827;
+			
+			// aapt resource value: 0x7F08006C
+			public const int none = 2131230828;
+			
+			// aapt resource value: 0x7F08006D
+			public const int normal = 2131230829;
+			
+			// aapt resource value: 0x7F08006E
+			public const int notification_background = 2131230830;
+			
+			// aapt resource value: 0x7F08006F
+			public const int notification_main_column = 2131230831;
+			
+			// aapt resource value: 0x7F080070
+			public const int notification_main_column_container = 2131230832;
+			
+			// aapt resource value: 0x7F080071
+			public const int parallax = 2131230833;
+			
+			// aapt resource value: 0x7F080072
+			public const int parentPanel = 2131230834;
+			
+			// aapt resource value: 0x7F080073
+			public const int pin = 2131230835;
+			
+			// aapt resource value: 0x7F080074
+			public const int progress_circular = 2131230836;
+			
+			// aapt resource value: 0x7F080075
+			public const int progress_horizontal = 2131230837;
+			
+			// aapt resource value: 0x7F080076
+			public const int radio = 2131230838;
+			
+			// aapt resource value: 0x7F080077
+			public const int right = 2131230839;
+			
+			// aapt resource value: 0x7F080078
+			public const int right_icon = 2131230840;
+			
+			// aapt resource value: 0x7F080079
+			public const int right_side = 2131230841;
+			
+			// aapt resource value: 0x7F08007A
+			public const int screen = 2131230842;
+			
+			// aapt resource value: 0x7F08007B
+			public const int scroll = 2131230843;
+			
+			// aapt resource value: 0x7F08007F
+			public const int scrollable = 2131230847;
+			
+			// aapt resource value: 0x7F08007C
+			public const int scrollIndicatorDown = 2131230844;
+			
+			// aapt resource value: 0x7F08007D
+			public const int scrollIndicatorUp = 2131230845;
+			
+			// aapt resource value: 0x7F08007E
+			public const int scrollView = 2131230846;
+			
+			// aapt resource value: 0x7F080080
+			public const int search_badge = 2131230848;
+			
+			// aapt resource value: 0x7F080081
+			public const int search_bar = 2131230849;
+			
+			// aapt resource value: 0x7F080082
+			public const int search_button = 2131230850;
+			
+			// aapt resource value: 0x7F080083
+			public const int search_close_btn = 2131230851;
+			
+			// aapt resource value: 0x7F080084
+			public const int search_edit_frame = 2131230852;
+			
+			// aapt resource value: 0x7F080085
+			public const int search_go_btn = 2131230853;
+			
+			// aapt resource value: 0x7F080086
+			public const int search_mag_icon = 2131230854;
+			
+			// aapt resource value: 0x7F080087
+			public const int search_plate = 2131230855;
+			
+			// aapt resource value: 0x7F080088
+			public const int search_src_text = 2131230856;
+			
+			// aapt resource value: 0x7F080089
+			public const int search_voice_btn = 2131230857;
+			
+			// aapt resource value: 0x7F08008A
+			public const int select_dialog_listview = 2131230858;
+			
+			// aapt resource value: 0x7F08008B
+			public const int shortcut = 2131230859;
+			
+			// aapt resource value: 0x7F08008C
+			public const int showCustom = 2131230860;
+			
+			// aapt resource value: 0x7F08008D
+			public const int showHome = 2131230861;
+			
+			// aapt resource value: 0x7F08008E
+			public const int showTitle = 2131230862;
+			
+			// aapt resource value: 0x7F08008F
+			public const int sliding_tabs = 2131230863;
+			
+			// aapt resource value: 0x7F080090
+			public const int smallLabel = 2131230864;
+			
+			// aapt resource value: 0x7F080091
+			public const int snackbar_action = 2131230865;
+			
+			// aapt resource value: 0x7F080092
+			public const int snackbar_text = 2131230866;
+			
+			// aapt resource value: 0x7F080093
+			public const int snap = 2131230867;
+			
+			// aapt resource value: 0x7F080094
+			public const int spacer = 2131230868;
+			
+			// aapt resource value: 0x7F080095
+			public const int split_action_bar = 2131230869;
+			
+			// aapt resource value: 0x7F080096
+			public const int src_atop = 2131230870;
+			
+			// aapt resource value: 0x7F080097
+			public const int src_in = 2131230871;
+			
+			// aapt resource value: 0x7F080098
+			public const int src_over = 2131230872;
+			
+			// aapt resource value: 0x7F080099
+			public const int start = 2131230873;
+			
+			// aapt resource value: 0x7F08009A
+			public const int status_bar_latest_event_content = 2131230874;
+			
+			// aapt resource value: 0x7F08009B
+			public const int submenuarrow = 2131230875;
+			
+			// aapt resource value: 0x7F08009C
+			public const int submit_area = 2131230876;
+			
+			// aapt resource value: 0x7F08009D
+			public const int tabMode = 2131230877;
+			
+			// aapt resource value: 0x7F08009E
+			public const int text = 2131230878;
+			
+			// aapt resource value: 0x7F08009F
+			public const int text2 = 2131230879;
+			
+			// aapt resource value: 0x7F0800A3
+			public const int textinput_counter = 2131230883;
+			
+			// aapt resource value: 0x7F0800A4
+			public const int textinput_error = 2131230884;
+			
+			// aapt resource value: 0x7F0800A0
+			public const int textSpacerNoButtons = 2131230880;
+			
+			// aapt resource value: 0x7F0800A1
+			public const int textSpacerNoTitle = 2131230881;
+			
+			// aapt resource value: 0x7F0800A2
+			public const int text_input_password_toggle = 2131230882;
+			
+			// aapt resource value: 0x7F0800A5
+			public const int time = 2131230885;
+			
+			// aapt resource value: 0x7F0800A6
+			public const int title = 2131230886;
+			
+			// aapt resource value: 0x7F0800A7
+			public const int titleDividerNoCustom = 2131230887;
+			
+			// aapt resource value: 0x7F0800A8
+			public const int title_template = 2131230888;
+			
+			// aapt resource value: 0x7F0800A9
+			public const int toolbar = 2131230889;
+			
+			// aapt resource value: 0x7F0800AA
+			public const int top = 2131230890;
+			
+			// aapt resource value: 0x7F0800AB
+			public const int topPanel = 2131230891;
+			
+			// aapt resource value: 0x7F0800AC
+			public const int touch_outside = 2131230892;
+			
+			// aapt resource value: 0x7F0800AD
+			public const int transition_current_scene = 2131230893;
+			
+			// aapt resource value: 0x7F0800AE
+			public const int transition_scene_layoutid_cache = 2131230894;
+			
+			// aapt resource value: 0x7F0800AF
+			public const int up = 2131230895;
+			
+			// aapt resource value: 0x7F0800B0
+			public const int useLogo = 2131230896;
+			
+			// aapt resource value: 0x7F0800B1
+			public const int view_offset_helper = 2131230897;
+			
+			// aapt resource value: 0x7F0800B2
+			public const int visible = 2131230898;
+			
+			// aapt resource value: 0x7F0800B3
+			public const int volume_item_container = 2131230899;
+			
+			// aapt resource value: 0x7F0800B4
+			public const int withText = 2131230900;
+			
+			// aapt resource value: 0x7F0800B5
+			public const int wrap_content = 2131230901;
 			
 			static Id()
 			{
@@ -84,14 +3327,280 @@ namespace Features.Forms.Droid
 			}
 		}
 		
+		public partial class Integer
+		{
+			
+			// aapt resource value: 0x7F090000
+			public const int abc_config_activityDefaultDur = 2131296256;
+			
+			// aapt resource value: 0x7F090001
+			public const int abc_config_activityShortDur = 2131296257;
+			
+			// aapt resource value: 0x7F090002
+			public const int app_bar_elevation_anim_duration = 2131296258;
+			
+			// aapt resource value: 0x7F090003
+			public const int bottom_sheet_slide_duration = 2131296259;
+			
+			// aapt resource value: 0x7F090004
+			public const int cancel_button_image_alpha = 2131296260;
+			
+			// aapt resource value: 0x7F090005
+			public const int design_snackbar_text_max_lines = 2131296261;
+			
+			// aapt resource value: 0x7F090006
+			public const int hide_password_duration = 2131296262;
+			
+			// aapt resource value: 0x7F090007
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296263;
+			
+			// aapt resource value: 0x7F090008
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131296264;
+			
+			// aapt resource value: 0x7F090009
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296265;
+			
+			// aapt resource value: 0x7F09000A
+			public const int show_password_duration = 2131296266;
+			
+			// aapt resource value: 0x7F09000B
+			public const int status_bar_notification_info_maxnum = 2131296267;
+			
+			static Integer()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Integer()
+			{
+			}
+		}
+		
+		public partial class Interpolator
+		{
+			
+			// aapt resource value: 0x7F0A0000
+			public const int mr_fast_out_slow_in = 2131361792;
+			
+			// aapt resource value: 0x7F0A0001
+			public const int mr_linear_out_slow_in = 2131361793;
+			
+			static Interpolator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Interpolator()
+			{
+			}
+		}
+		
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7F030000
-			public const int Tabbar = 2130903040;
+			// aapt resource value: 0x7F0B0000
+			public const int abc_action_bar_title_item = 2131427328;
 			
-			// aapt resource value: 0x7F030001
-			public const int Toolbar = 2130903041;
+			// aapt resource value: 0x7F0B0001
+			public const int abc_action_bar_up_container = 2131427329;
+			
+			// aapt resource value: 0x7F0B0002
+			public const int abc_action_bar_view_list_nav_layout = 2131427330;
+			
+			// aapt resource value: 0x7F0B0003
+			public const int abc_action_menu_item_layout = 2131427331;
+			
+			// aapt resource value: 0x7F0B0004
+			public const int abc_action_menu_layout = 2131427332;
+			
+			// aapt resource value: 0x7F0B0005
+			public const int abc_action_mode_bar = 2131427333;
+			
+			// aapt resource value: 0x7F0B0006
+			public const int abc_action_mode_close_item_material = 2131427334;
+			
+			// aapt resource value: 0x7F0B0007
+			public const int abc_activity_chooser_view = 2131427335;
+			
+			// aapt resource value: 0x7F0B0008
+			public const int abc_activity_chooser_view_list_item = 2131427336;
+			
+			// aapt resource value: 0x7F0B0009
+			public const int abc_alert_dialog_button_bar_material = 2131427337;
+			
+			// aapt resource value: 0x7F0B000A
+			public const int abc_alert_dialog_material = 2131427338;
+			
+			// aapt resource value: 0x7F0B000B
+			public const int abc_alert_dialog_title_material = 2131427339;
+			
+			// aapt resource value: 0x7F0B000C
+			public const int abc_dialog_title_material = 2131427340;
+			
+			// aapt resource value: 0x7F0B000D
+			public const int abc_expanded_menu_layout = 2131427341;
+			
+			// aapt resource value: 0x7F0B000E
+			public const int abc_list_menu_item_checkbox = 2131427342;
+			
+			// aapt resource value: 0x7F0B000F
+			public const int abc_list_menu_item_icon = 2131427343;
+			
+			// aapt resource value: 0x7F0B0010
+			public const int abc_list_menu_item_layout = 2131427344;
+			
+			// aapt resource value: 0x7F0B0011
+			public const int abc_list_menu_item_radio = 2131427345;
+			
+			// aapt resource value: 0x7F0B0012
+			public const int abc_popup_menu_header_item_layout = 2131427346;
+			
+			// aapt resource value: 0x7F0B0013
+			public const int abc_popup_menu_item_layout = 2131427347;
+			
+			// aapt resource value: 0x7F0B0014
+			public const int abc_screen_content_include = 2131427348;
+			
+			// aapt resource value: 0x7F0B0015
+			public const int abc_screen_simple = 2131427349;
+			
+			// aapt resource value: 0x7F0B0016
+			public const int abc_screen_simple_overlay_action_mode = 2131427350;
+			
+			// aapt resource value: 0x7F0B0017
+			public const int abc_screen_toolbar = 2131427351;
+			
+			// aapt resource value: 0x7F0B0018
+			public const int abc_search_dropdown_item_icons_2line = 2131427352;
+			
+			// aapt resource value: 0x7F0B0019
+			public const int abc_search_view = 2131427353;
+			
+			// aapt resource value: 0x7F0B001A
+			public const int abc_select_dialog_material = 2131427354;
+			
+			// aapt resource value: 0x7F0B001B
+			public const int design_bottom_navigation_item = 2131427355;
+			
+			// aapt resource value: 0x7F0B001C
+			public const int design_bottom_sheet_dialog = 2131427356;
+			
+			// aapt resource value: 0x7F0B001D
+			public const int design_layout_snackbar = 2131427357;
+			
+			// aapt resource value: 0x7F0B001E
+			public const int design_layout_snackbar_include = 2131427358;
+			
+			// aapt resource value: 0x7F0B001F
+			public const int design_layout_tab_icon = 2131427359;
+			
+			// aapt resource value: 0x7F0B0020
+			public const int design_layout_tab_text = 2131427360;
+			
+			// aapt resource value: 0x7F0B0021
+			public const int design_menu_item_action_area = 2131427361;
+			
+			// aapt resource value: 0x7F0B0022
+			public const int design_navigation_item = 2131427362;
+			
+			// aapt resource value: 0x7F0B0023
+			public const int design_navigation_item_header = 2131427363;
+			
+			// aapt resource value: 0x7F0B0024
+			public const int design_navigation_item_separator = 2131427364;
+			
+			// aapt resource value: 0x7F0B0025
+			public const int design_navigation_item_subheader = 2131427365;
+			
+			// aapt resource value: 0x7F0B0026
+			public const int design_navigation_menu = 2131427366;
+			
+			// aapt resource value: 0x7F0B0027
+			public const int design_navigation_menu_item = 2131427367;
+			
+			// aapt resource value: 0x7F0B0028
+			public const int design_text_input_password_icon = 2131427368;
+			
+			// aapt resource value: 0x7F0B0029
+			public const int mr_chooser_dialog = 2131427369;
+			
+			// aapt resource value: 0x7F0B002A
+			public const int mr_chooser_list_item = 2131427370;
+			
+			// aapt resource value: 0x7F0B002B
+			public const int mr_controller_material_dialog_b = 2131427371;
+			
+			// aapt resource value: 0x7F0B002C
+			public const int mr_controller_volume_item = 2131427372;
+			
+			// aapt resource value: 0x7F0B002D
+			public const int mr_playback_control = 2131427373;
+			
+			// aapt resource value: 0x7F0B002E
+			public const int mr_volume_control = 2131427374;
+			
+			// aapt resource value: 0x7F0B002F
+			public const int notification_action = 2131427375;
+			
+			// aapt resource value: 0x7F0B0030
+			public const int notification_action_tombstone = 2131427376;
+			
+			// aapt resource value: 0x7F0B0031
+			public const int notification_media_action = 2131427377;
+			
+			// aapt resource value: 0x7F0B0032
+			public const int notification_media_cancel_action = 2131427378;
+			
+			// aapt resource value: 0x7F0B0033
+			public const int notification_template_big_media = 2131427379;
+			
+			// aapt resource value: 0x7F0B0034
+			public const int notification_template_big_media_custom = 2131427380;
+			
+			// aapt resource value: 0x7F0B0035
+			public const int notification_template_big_media_narrow = 2131427381;
+			
+			// aapt resource value: 0x7F0B0036
+			public const int notification_template_big_media_narrow_custom = 2131427382;
+			
+			// aapt resource value: 0x7F0B0037
+			public const int notification_template_custom_big = 2131427383;
+			
+			// aapt resource value: 0x7F0B0038
+			public const int notification_template_icon_group = 2131427384;
+			
+			// aapt resource value: 0x7F0B0039
+			public const int notification_template_lines_media = 2131427385;
+			
+			// aapt resource value: 0x7F0B003A
+			public const int notification_template_media = 2131427386;
+			
+			// aapt resource value: 0x7F0B003B
+			public const int notification_template_media_custom = 2131427387;
+			
+			// aapt resource value: 0x7F0B003C
+			public const int notification_template_part_chronometer = 2131427388;
+			
+			// aapt resource value: 0x7F0B003D
+			public const int notification_template_part_time = 2131427389;
+			
+			// aapt resource value: 0x7F0B003E
+			public const int select_dialog_item_material = 2131427390;
+			
+			// aapt resource value: 0x7F0B003F
+			public const int select_dialog_multichoice_material = 2131427391;
+			
+			// aapt resource value: 0x7F0B0040
+			public const int select_dialog_singlechoice_material = 2131427392;
+			
+			// aapt resource value: 0x7F0B0041
+			public const int support_simple_spinner_dropdown_item = 2131427393;
+			
+			// aapt resource value: 0x7F0B0042
+			public const int Tabbar = 2131427394;
+			
+			// aapt resource value: 0x7F0B0043
+			public const int Toolbar = 2131427395;
 			
 			static Layout()
 			{
@@ -106,14 +3615,14 @@ namespace Features.Forms.Droid
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0x7F040000
-			public const int icon = 2130968576;
+			// aapt resource value: 0x7F0C0000
+			public const int icon = 2131492864;
 			
-			// aapt resource value: 0x7F040001
-			public const int icon_round = 2130968577;
+			// aapt resource value: 0x7F0C0001
+			public const int icon_round = 2131492865;
 			
-			// aapt resource value: 0x7F040002
-			public const int launcher_foreground = 2130968578;
+			// aapt resource value: 0x7F0C0002
+			public const int launcher_foreground = 2131492866;
 			
 			static Mipmap()
 			{
@@ -125,17 +3634,1395 @@ namespace Features.Forms.Droid
 			}
 		}
 		
+		public partial class String
+		{
+			
+			// aapt resource value: 0x7F0D0000
+			public const int abc_action_bar_home_description = 2131558400;
+			
+			// aapt resource value: 0x7F0D0001
+			public const int abc_action_bar_home_description_format = 2131558401;
+			
+			// aapt resource value: 0x7F0D0002
+			public const int abc_action_bar_home_subtitle_description_format = 2131558402;
+			
+			// aapt resource value: 0x7F0D0003
+			public const int abc_action_bar_up_description = 2131558403;
+			
+			// aapt resource value: 0x7F0D0004
+			public const int abc_action_menu_overflow_description = 2131558404;
+			
+			// aapt resource value: 0x7F0D0005
+			public const int abc_action_mode_done = 2131558405;
+			
+			// aapt resource value: 0x7F0D0007
+			public const int abc_activitychooserview_choose_application = 2131558407;
+			
+			// aapt resource value: 0x7F0D0006
+			public const int abc_activity_chooser_view_see_all = 2131558406;
+			
+			// aapt resource value: 0x7F0D0008
+			public const int abc_capital_off = 2131558408;
+			
+			// aapt resource value: 0x7F0D0009
+			public const int abc_capital_on = 2131558409;
+			
+			// aapt resource value: 0x7F0D000A
+			public const int abc_font_family_body_1_material = 2131558410;
+			
+			// aapt resource value: 0x7F0D000B
+			public const int abc_font_family_body_2_material = 2131558411;
+			
+			// aapt resource value: 0x7F0D000C
+			public const int abc_font_family_button_material = 2131558412;
+			
+			// aapt resource value: 0x7F0D000D
+			public const int abc_font_family_caption_material = 2131558413;
+			
+			// aapt resource value: 0x7F0D000E
+			public const int abc_font_family_display_1_material = 2131558414;
+			
+			// aapt resource value: 0x7F0D000F
+			public const int abc_font_family_display_2_material = 2131558415;
+			
+			// aapt resource value: 0x7F0D0010
+			public const int abc_font_family_display_3_material = 2131558416;
+			
+			// aapt resource value: 0x7F0D0011
+			public const int abc_font_family_display_4_material = 2131558417;
+			
+			// aapt resource value: 0x7F0D0012
+			public const int abc_font_family_headline_material = 2131558418;
+			
+			// aapt resource value: 0x7F0D0013
+			public const int abc_font_family_menu_material = 2131558419;
+			
+			// aapt resource value: 0x7F0D0014
+			public const int abc_font_family_subhead_material = 2131558420;
+			
+			// aapt resource value: 0x7F0D0015
+			public const int abc_font_family_title_material = 2131558421;
+			
+			// aapt resource value: 0x7F0D0017
+			public const int abc_searchview_description_clear = 2131558423;
+			
+			// aapt resource value: 0x7F0D0018
+			public const int abc_searchview_description_query = 2131558424;
+			
+			// aapt resource value: 0x7F0D0019
+			public const int abc_searchview_description_search = 2131558425;
+			
+			// aapt resource value: 0x7F0D001A
+			public const int abc_searchview_description_submit = 2131558426;
+			
+			// aapt resource value: 0x7F0D001B
+			public const int abc_searchview_description_voice = 2131558427;
+			
+			// aapt resource value: 0x7F0D0016
+			public const int abc_search_hint = 2131558422;
+			
+			// aapt resource value: 0x7F0D001C
+			public const int abc_shareactionprovider_share_with = 2131558428;
+			
+			// aapt resource value: 0x7F0D001D
+			public const int abc_shareactionprovider_share_with_application = 2131558429;
+			
+			// aapt resource value: 0x7F0D001E
+			public const int abc_toolbar_collapse_description = 2131558430;
+			
+			// aapt resource value: 0x7F0D001F
+			public const int appbar_scrolling_view_behavior = 2131558431;
+			
+			// aapt resource value: 0x7F0D0020
+			public const int bottom_sheet_behavior = 2131558432;
+			
+			// aapt resource value: 0x7F0D0021
+			public const int character_counter_pattern = 2131558433;
+			
+			// aapt resource value: 0x7F0D0022
+			public const int mr_button_content_description = 2131558434;
+			
+			// aapt resource value: 0x7F0D0023
+			public const int mr_cast_button_connected = 2131558435;
+			
+			// aapt resource value: 0x7F0D0024
+			public const int mr_cast_button_connecting = 2131558436;
+			
+			// aapt resource value: 0x7F0D0025
+			public const int mr_cast_button_disconnected = 2131558437;
+			
+			// aapt resource value: 0x7F0D0026
+			public const int mr_chooser_searching = 2131558438;
+			
+			// aapt resource value: 0x7F0D0027
+			public const int mr_chooser_title = 2131558439;
+			
+			// aapt resource value: 0x7F0D0028
+			public const int mr_controller_album_art = 2131558440;
+			
+			// aapt resource value: 0x7F0D0029
+			public const int mr_controller_casting_screen = 2131558441;
+			
+			// aapt resource value: 0x7F0D002A
+			public const int mr_controller_close_description = 2131558442;
+			
+			// aapt resource value: 0x7F0D002B
+			public const int mr_controller_collapse_group = 2131558443;
+			
+			// aapt resource value: 0x7F0D002C
+			public const int mr_controller_disconnect = 2131558444;
+			
+			// aapt resource value: 0x7F0D002D
+			public const int mr_controller_expand_group = 2131558445;
+			
+			// aapt resource value: 0x7F0D002E
+			public const int mr_controller_no_info_available = 2131558446;
+			
+			// aapt resource value: 0x7F0D002F
+			public const int mr_controller_no_media_selected = 2131558447;
+			
+			// aapt resource value: 0x7F0D0030
+			public const int mr_controller_pause = 2131558448;
+			
+			// aapt resource value: 0x7F0D0031
+			public const int mr_controller_play = 2131558449;
+			
+			// aapt resource value: 0x7F0D0032
+			public const int mr_controller_stop = 2131558450;
+			
+			// aapt resource value: 0x7F0D0033
+			public const int mr_controller_stop_casting = 2131558451;
+			
+			// aapt resource value: 0x7F0D0034
+			public const int mr_controller_volume_slider = 2131558452;
+			
+			// aapt resource value: 0x7F0D0035
+			public const int mr_system_route_name = 2131558453;
+			
+			// aapt resource value: 0x7F0D0036
+			public const int mr_user_route_category_name = 2131558454;
+			
+			// aapt resource value: 0x7F0D0037
+			public const int password_toggle_content_description = 2131558455;
+			
+			// aapt resource value: 0x7F0D0038
+			public const int path_password_eye = 2131558456;
+			
+			// aapt resource value: 0x7F0D0039
+			public const int path_password_eye_mask_strike_through = 2131558457;
+			
+			// aapt resource value: 0x7F0D003A
+			public const int path_password_eye_mask_visible = 2131558458;
+			
+			// aapt resource value: 0x7F0D003B
+			public const int path_password_strike_through = 2131558459;
+			
+			// aapt resource value: 0x7F0D003C
+			public const int search_menu_title = 2131558460;
+			
+			// aapt resource value: 0x7F0D003D
+			public const int status_bar_notification_info_overflow = 2131558461;
+			
+			static String()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private String()
+			{
+			}
+		}
+		
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7F050000
-			public const int AppCompatDialogStyle = 2131034112;
+			// aapt resource value: 0x7F0E0000
+			public const int AlertDialog_AppCompat = 2131623936;
 			
-			// aapt resource value: 0x7F050001
-			public const int MainTheme = 2131034113;
+			// aapt resource value: 0x7F0E0001
+			public const int AlertDialog_AppCompat_Light = 2131623937;
 			
-			// aapt resource value: 0x7F050002
-			public const int MainTheme_Base = 2131034114;
+			// aapt resource value: 0x7F0E0002
+			public const int Animation_AppCompat_Dialog = 2131623938;
+			
+			// aapt resource value: 0x7F0E0003
+			public const int Animation_AppCompat_DropDownUp = 2131623939;
+			
+			// aapt resource value: 0x7F0E0004
+			public const int Animation_Design_BottomSheetDialog = 2131623940;
+			
+			// aapt resource value: 0x7F0E0005
+			public const int AppCompatDialogStyle = 2131623941;
+			
+			// aapt resource value: 0x7F0E0006
+			public const int Base_AlertDialog_AppCompat = 2131623942;
+			
+			// aapt resource value: 0x7F0E0007
+			public const int Base_AlertDialog_AppCompat_Light = 2131623943;
+			
+			// aapt resource value: 0x7F0E0008
+			public const int Base_Animation_AppCompat_Dialog = 2131623944;
+			
+			// aapt resource value: 0x7F0E0009
+			public const int Base_Animation_AppCompat_DropDownUp = 2131623945;
+			
+			// aapt resource value: 0x7F0E000A
+			public const int Base_CardView = 2131623946;
+			
+			// aapt resource value: 0x7F0E000C
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131623948;
+			
+			// aapt resource value: 0x7F0E000B
+			public const int Base_DialogWindowTitle_AppCompat = 2131623947;
+			
+			// aapt resource value: 0x7F0E000D
+			public const int Base_TextAppearance_AppCompat = 2131623949;
+			
+			// aapt resource value: 0x7F0E000E
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131623950;
+			
+			// aapt resource value: 0x7F0E000F
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131623951;
+			
+			// aapt resource value: 0x7F0E0010
+			public const int Base_TextAppearance_AppCompat_Button = 2131623952;
+			
+			// aapt resource value: 0x7F0E0011
+			public const int Base_TextAppearance_AppCompat_Caption = 2131623953;
+			
+			// aapt resource value: 0x7F0E0012
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131623954;
+			
+			// aapt resource value: 0x7F0E0013
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131623955;
+			
+			// aapt resource value: 0x7F0E0014
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131623956;
+			
+			// aapt resource value: 0x7F0E0015
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131623957;
+			
+			// aapt resource value: 0x7F0E0016
+			public const int Base_TextAppearance_AppCompat_Headline = 2131623958;
+			
+			// aapt resource value: 0x7F0E0017
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131623959;
+			
+			// aapt resource value: 0x7F0E0018
+			public const int Base_TextAppearance_AppCompat_Large = 2131623960;
+			
+			// aapt resource value: 0x7F0E0019
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131623961;
+			
+			// aapt resource value: 0x7F0E001A
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131623962;
+			
+			// aapt resource value: 0x7F0E001B
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131623963;
+			
+			// aapt resource value: 0x7F0E001C
+			public const int Base_TextAppearance_AppCompat_Medium = 2131623964;
+			
+			// aapt resource value: 0x7F0E001D
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131623965;
+			
+			// aapt resource value: 0x7F0E001E
+			public const int Base_TextAppearance_AppCompat_Menu = 2131623966;
+			
+			// aapt resource value: 0x7F0E001F
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131623967;
+			
+			// aapt resource value: 0x7F0E0020
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131623968;
+			
+			// aapt resource value: 0x7F0E0021
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131623969;
+			
+			// aapt resource value: 0x7F0E0022
+			public const int Base_TextAppearance_AppCompat_Small = 2131623970;
+			
+			// aapt resource value: 0x7F0E0023
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131623971;
+			
+			// aapt resource value: 0x7F0E0024
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131623972;
+			
+			// aapt resource value: 0x7F0E0025
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131623973;
+			
+			// aapt resource value: 0x7F0E0026
+			public const int Base_TextAppearance_AppCompat_Title = 2131623974;
+			
+			// aapt resource value: 0x7F0E0027
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131623975;
+			
+			// aapt resource value: 0x7F0E0028
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131623976;
+			
+			// aapt resource value: 0x7F0E0029
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131623977;
+			
+			// aapt resource value: 0x7F0E002A
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131623978;
+			
+			// aapt resource value: 0x7F0E002B
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131623979;
+			
+			// aapt resource value: 0x7F0E002C
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131623980;
+			
+			// aapt resource value: 0x7F0E002D
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131623981;
+			
+			// aapt resource value: 0x7F0E002E
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131623982;
+			
+			// aapt resource value: 0x7F0E002F
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131623983;
+			
+			// aapt resource value: 0x7F0E0030
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131623984;
+			
+			// aapt resource value: 0x7F0E0031
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131623985;
+			
+			// aapt resource value: 0x7F0E0032
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131623986;
+			
+			// aapt resource value: 0x7F0E0033
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131623987;
+			
+			// aapt resource value: 0x7F0E0034
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131623988;
+			
+			// aapt resource value: 0x7F0E0035
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131623989;
+			
+			// aapt resource value: 0x7F0E0036
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131623990;
+			
+			// aapt resource value: 0x7F0E0037
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131623991;
+			
+			// aapt resource value: 0x7F0E0038
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131623992;
+			
+			// aapt resource value: 0x7F0E0039
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131623993;
+			
+			// aapt resource value: 0x7F0E003A
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131623994;
+			
+			// aapt resource value: 0x7F0E003B
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131623995;
+			
+			// aapt resource value: 0x7F0E004A
+			public const int Base_ThemeOverlay_AppCompat = 2131624010;
+			
+			// aapt resource value: 0x7F0E004B
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131624011;
+			
+			// aapt resource value: 0x7F0E004C
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131624012;
+			
+			// aapt resource value: 0x7F0E004D
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131624013;
+			
+			// aapt resource value: 0x7F0E004E
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131624014;
+			
+			// aapt resource value: 0x7F0E004F
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131624015;
+			
+			// aapt resource value: 0x7F0E0050
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131624016;
+			
+			// aapt resource value: 0x7F0E003C
+			public const int Base_Theme_AppCompat = 2131623996;
+			
+			// aapt resource value: 0x7F0E003D
+			public const int Base_Theme_AppCompat_CompactMenu = 2131623997;
+			
+			// aapt resource value: 0x7F0E003E
+			public const int Base_Theme_AppCompat_Dialog = 2131623998;
+			
+			// aapt resource value: 0x7F0E0042
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131624002;
+			
+			// aapt resource value: 0x7F0E003F
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131623999;
+			
+			// aapt resource value: 0x7F0E0040
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131624000;
+			
+			// aapt resource value: 0x7F0E0041
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131624001;
+			
+			// aapt resource value: 0x7F0E0043
+			public const int Base_Theme_AppCompat_Light = 2131624003;
+			
+			// aapt resource value: 0x7F0E0044
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131624004;
+			
+			// aapt resource value: 0x7F0E0045
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131624005;
+			
+			// aapt resource value: 0x7F0E0049
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131624009;
+			
+			// aapt resource value: 0x7F0E0046
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131624006;
+			
+			// aapt resource value: 0x7F0E0047
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131624007;
+			
+			// aapt resource value: 0x7F0E0048
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131624008;
+			
+			// aapt resource value: 0x7F0E0053
+			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131624019;
+			
+			// aapt resource value: 0x7F0E0051
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131624017;
+			
+			// aapt resource value: 0x7F0E0052
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131624018;
+			
+			// aapt resource value: 0x7F0E0054
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131624020;
+			
+			// aapt resource value: 0x7F0E0055
+			public const int Base_V12_Widget_AppCompat_EditText = 2131624021;
+			
+			// aapt resource value: 0x7F0E005A
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131624026;
+			
+			// aapt resource value: 0x7F0E0056
+			public const int Base_V21_Theme_AppCompat = 2131624022;
+			
+			// aapt resource value: 0x7F0E0057
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131624023;
+			
+			// aapt resource value: 0x7F0E0058
+			public const int Base_V21_Theme_AppCompat_Light = 2131624024;
+			
+			// aapt resource value: 0x7F0E0059
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131624025;
+			
+			// aapt resource value: 0x7F0E005B
+			public const int Base_V22_Theme_AppCompat = 2131624027;
+			
+			// aapt resource value: 0x7F0E005C
+			public const int Base_V22_Theme_AppCompat_Light = 2131624028;
+			
+			// aapt resource value: 0x7F0E005D
+			public const int Base_V23_Theme_AppCompat = 2131624029;
+			
+			// aapt resource value: 0x7F0E005E
+			public const int Base_V23_Theme_AppCompat_Light = 2131624030;
+			
+			// aapt resource value: 0x7F0E0063
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131624035;
+			
+			// aapt resource value: 0x7F0E005F
+			public const int Base_V7_Theme_AppCompat = 2131624031;
+			
+			// aapt resource value: 0x7F0E0060
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131624032;
+			
+			// aapt resource value: 0x7F0E0061
+			public const int Base_V7_Theme_AppCompat_Light = 2131624033;
+			
+			// aapt resource value: 0x7F0E0062
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131624034;
+			
+			// aapt resource value: 0x7F0E0064
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131624036;
+			
+			// aapt resource value: 0x7F0E0065
+			public const int Base_V7_Widget_AppCompat_EditText = 2131624037;
+			
+			// aapt resource value: 0x7F0E0066
+			public const int Base_Widget_AppCompat_ActionBar = 2131624038;
+			
+			// aapt resource value: 0x7F0E0067
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131624039;
+			
+			// aapt resource value: 0x7F0E0068
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131624040;
+			
+			// aapt resource value: 0x7F0E0069
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131624041;
+			
+			// aapt resource value: 0x7F0E006A
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131624042;
+			
+			// aapt resource value: 0x7F0E006B
+			public const int Base_Widget_AppCompat_ActionButton = 2131624043;
+			
+			// aapt resource value: 0x7F0E006C
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131624044;
+			
+			// aapt resource value: 0x7F0E006D
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131624045;
+			
+			// aapt resource value: 0x7F0E006E
+			public const int Base_Widget_AppCompat_ActionMode = 2131624046;
+			
+			// aapt resource value: 0x7F0E006F
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131624047;
+			
+			// aapt resource value: 0x7F0E0070
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131624048;
+			
+			// aapt resource value: 0x7F0E0071
+			public const int Base_Widget_AppCompat_Button = 2131624049;
+			
+			// aapt resource value: 0x7F0E0077
+			public const int Base_Widget_AppCompat_ButtonBar = 2131624055;
+			
+			// aapt resource value: 0x7F0E0078
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131624056;
+			
+			// aapt resource value: 0x7F0E0072
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131624050;
+			
+			// aapt resource value: 0x7F0E0073
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131624051;
+			
+			// aapt resource value: 0x7F0E0074
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624052;
+			
+			// aapt resource value: 0x7F0E0075
+			public const int Base_Widget_AppCompat_Button_Colored = 2131624053;
+			
+			// aapt resource value: 0x7F0E0076
+			public const int Base_Widget_AppCompat_Button_Small = 2131624054;
+			
+			// aapt resource value: 0x7F0E0079
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131624057;
+			
+			// aapt resource value: 0x7F0E007A
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131624058;
+			
+			// aapt resource value: 0x7F0E007B
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131624059;
+			
+			// aapt resource value: 0x7F0E007C
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131624060;
+			
+			// aapt resource value: 0x7F0E007D
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131624061;
+			
+			// aapt resource value: 0x7F0E007E
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131624062;
+			
+			// aapt resource value: 0x7F0E007F
+			public const int Base_Widget_AppCompat_EditText = 2131624063;
+			
+			// aapt resource value: 0x7F0E0080
+			public const int Base_Widget_AppCompat_ImageButton = 2131624064;
+			
+			// aapt resource value: 0x7F0E0081
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131624065;
+			
+			// aapt resource value: 0x7F0E0082
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131624066;
+			
+			// aapt resource value: 0x7F0E0083
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131624067;
+			
+			// aapt resource value: 0x7F0E0084
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131624068;
+			
+			// aapt resource value: 0x7F0E0085
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624069;
+			
+			// aapt resource value: 0x7F0E0086
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131624070;
+			
+			// aapt resource value: 0x7F0E0087
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131624071;
+			
+			// aapt resource value: 0x7F0E0088
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131624072;
+			
+			// aapt resource value: 0x7F0E0089
+			public const int Base_Widget_AppCompat_ListMenuView = 2131624073;
+			
+			// aapt resource value: 0x7F0E008A
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131624074;
+			
+			// aapt resource value: 0x7F0E008B
+			public const int Base_Widget_AppCompat_ListView = 2131624075;
+			
+			// aapt resource value: 0x7F0E008C
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131624076;
+			
+			// aapt resource value: 0x7F0E008D
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131624077;
+			
+			// aapt resource value: 0x7F0E008E
+			public const int Base_Widget_AppCompat_PopupMenu = 2131624078;
+			
+			// aapt resource value: 0x7F0E008F
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131624079;
+			
+			// aapt resource value: 0x7F0E0090
+			public const int Base_Widget_AppCompat_PopupWindow = 2131624080;
+			
+			// aapt resource value: 0x7F0E0091
+			public const int Base_Widget_AppCompat_ProgressBar = 2131624081;
+			
+			// aapt resource value: 0x7F0E0092
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131624082;
+			
+			// aapt resource value: 0x7F0E0093
+			public const int Base_Widget_AppCompat_RatingBar = 2131624083;
+			
+			// aapt resource value: 0x7F0E0094
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131624084;
+			
+			// aapt resource value: 0x7F0E0095
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131624085;
+			
+			// aapt resource value: 0x7F0E0096
+			public const int Base_Widget_AppCompat_SearchView = 2131624086;
+			
+			// aapt resource value: 0x7F0E0097
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131624087;
+			
+			// aapt resource value: 0x7F0E0098
+			public const int Base_Widget_AppCompat_SeekBar = 2131624088;
+			
+			// aapt resource value: 0x7F0E0099
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131624089;
+			
+			// aapt resource value: 0x7F0E009A
+			public const int Base_Widget_AppCompat_Spinner = 2131624090;
+			
+			// aapt resource value: 0x7F0E009B
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131624091;
+			
+			// aapt resource value: 0x7F0E009C
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131624092;
+			
+			// aapt resource value: 0x7F0E009D
+			public const int Base_Widget_AppCompat_Toolbar = 2131624093;
+			
+			// aapt resource value: 0x7F0E009E
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131624094;
+			
+			// aapt resource value: 0x7F0E009F
+			public const int Base_Widget_Design_AppBarLayout = 2131624095;
+			
+			// aapt resource value: 0x7F0E00A0
+			public const int Base_Widget_Design_TabLayout = 2131624096;
+			
+			// aapt resource value: 0x7F0E00A1
+			public const int CardView = 2131624097;
+			
+			// aapt resource value: 0x7F0E00A2
+			public const int CardView_Dark = 2131624098;
+			
+			// aapt resource value: 0x7F0E00A3
+			public const int CardView_Light = 2131624099;
+			
+			// aapt resource value: 0x7F0E00A4
+			public const int MainTheme = 2131624100;
+			
+			// aapt resource value: 0x7F0E00A5
+			public const int MainTheme_Base = 2131624101;
+			
+			// aapt resource value: 0x7F0E00A6
+			public const int Platform_AppCompat = 2131624102;
+			
+			// aapt resource value: 0x7F0E00A7
+			public const int Platform_AppCompat_Light = 2131624103;
+			
+			// aapt resource value: 0x7F0E00A8
+			public const int Platform_ThemeOverlay_AppCompat = 2131624104;
+			
+			// aapt resource value: 0x7F0E00A9
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131624105;
+			
+			// aapt resource value: 0x7F0E00AA
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131624106;
+			
+			// aapt resource value: 0x7F0E00AB
+			public const int Platform_V11_AppCompat = 2131624107;
+			
+			// aapt resource value: 0x7F0E00AC
+			public const int Platform_V11_AppCompat_Light = 2131624108;
+			
+			// aapt resource value: 0x7F0E00AD
+			public const int Platform_V14_AppCompat = 2131624109;
+			
+			// aapt resource value: 0x7F0E00AE
+			public const int Platform_V14_AppCompat_Light = 2131624110;
+			
+			// aapt resource value: 0x7F0E00AF
+			public const int Platform_V21_AppCompat = 2131624111;
+			
+			// aapt resource value: 0x7F0E00B0
+			public const int Platform_V21_AppCompat_Light = 2131624112;
+			
+			// aapt resource value: 0x7F0E00B1
+			public const int Platform_V25_AppCompat = 2131624113;
+			
+			// aapt resource value: 0x7F0E00B2
+			public const int Platform_V25_AppCompat_Light = 2131624114;
+			
+			// aapt resource value: 0x7F0E00B3
+			public const int Platform_Widget_AppCompat_Spinner = 2131624115;
+			
+			// aapt resource value: 0x7F0E00B4
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131624116;
+			
+			// aapt resource value: 0x7F0E00B5
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131624117;
+			
+			// aapt resource value: 0x7F0E00B6
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131624118;
+			
+			// aapt resource value: 0x7F0E00B7
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131624119;
+			
+			// aapt resource value: 0x7F0E00B8
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131624120;
+			
+			// aapt resource value: 0x7F0E00B9
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131624121;
+			
+			// aapt resource value: 0x7F0E00BF
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131624127;
+			
+			// aapt resource value: 0x7F0E00BA
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131624122;
+			
+			// aapt resource value: 0x7F0E00BB
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131624123;
+			
+			// aapt resource value: 0x7F0E00BC
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131624124;
+			
+			// aapt resource value: 0x7F0E00BD
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131624125;
+			
+			// aapt resource value: 0x7F0E00BE
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131624126;
+			
+			// aapt resource value: 0x7F0E00C0
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131624128;
+			
+			// aapt resource value: 0x7F0E00C1
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131624129;
+			
+			// aapt resource value: 0x7F0E00C2
+			public const int TextAppearance_AppCompat = 2131624130;
+			
+			// aapt resource value: 0x7F0E00C3
+			public const int TextAppearance_AppCompat_Body1 = 2131624131;
+			
+			// aapt resource value: 0x7F0E00C4
+			public const int TextAppearance_AppCompat_Body2 = 2131624132;
+			
+			// aapt resource value: 0x7F0E00C5
+			public const int TextAppearance_AppCompat_Button = 2131624133;
+			
+			// aapt resource value: 0x7F0E00C6
+			public const int TextAppearance_AppCompat_Caption = 2131624134;
+			
+			// aapt resource value: 0x7F0E00C7
+			public const int TextAppearance_AppCompat_Display1 = 2131624135;
+			
+			// aapt resource value: 0x7F0E00C8
+			public const int TextAppearance_AppCompat_Display2 = 2131624136;
+			
+			// aapt resource value: 0x7F0E00C9
+			public const int TextAppearance_AppCompat_Display3 = 2131624137;
+			
+			// aapt resource value: 0x7F0E00CA
+			public const int TextAppearance_AppCompat_Display4 = 2131624138;
+			
+			// aapt resource value: 0x7F0E00CB
+			public const int TextAppearance_AppCompat_Headline = 2131624139;
+			
+			// aapt resource value: 0x7F0E00CC
+			public const int TextAppearance_AppCompat_Inverse = 2131624140;
+			
+			// aapt resource value: 0x7F0E00CD
+			public const int TextAppearance_AppCompat_Large = 2131624141;
+			
+			// aapt resource value: 0x7F0E00CE
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131624142;
+			
+			// aapt resource value: 0x7F0E00CF
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131624143;
+			
+			// aapt resource value: 0x7F0E00D0
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131624144;
+			
+			// aapt resource value: 0x7F0E00D1
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131624145;
+			
+			// aapt resource value: 0x7F0E00D2
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131624146;
+			
+			// aapt resource value: 0x7F0E00D3
+			public const int TextAppearance_AppCompat_Medium = 2131624147;
+			
+			// aapt resource value: 0x7F0E00D4
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131624148;
+			
+			// aapt resource value: 0x7F0E00D5
+			public const int TextAppearance_AppCompat_Menu = 2131624149;
+			
+			// aapt resource value: 0x7F0E00D6
+			public const int TextAppearance_AppCompat_Notification = 2131624150;
+			
+			// aapt resource value: 0x7F0E00D7
+			public const int TextAppearance_AppCompat_Notification_Info = 2131624151;
+			
+			// aapt resource value: 0x7F0E00D8
+			public const int TextAppearance_AppCompat_Notification_Info_Media = 2131624152;
+			
+			// aapt resource value: 0x7F0E00D9
+			public const int TextAppearance_AppCompat_Notification_Line2 = 2131624153;
+			
+			// aapt resource value: 0x7F0E00DA
+			public const int TextAppearance_AppCompat_Notification_Line2_Media = 2131624154;
+			
+			// aapt resource value: 0x7F0E00DB
+			public const int TextAppearance_AppCompat_Notification_Media = 2131624155;
+			
+			// aapt resource value: 0x7F0E00DC
+			public const int TextAppearance_AppCompat_Notification_Time = 2131624156;
+			
+			// aapt resource value: 0x7F0E00DD
+			public const int TextAppearance_AppCompat_Notification_Time_Media = 2131624157;
+			
+			// aapt resource value: 0x7F0E00DE
+			public const int TextAppearance_AppCompat_Notification_Title = 2131624158;
+			
+			// aapt resource value: 0x7F0E00DF
+			public const int TextAppearance_AppCompat_Notification_Title_Media = 2131624159;
+			
+			// aapt resource value: 0x7F0E00E0
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131624160;
+			
+			// aapt resource value: 0x7F0E00E1
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131624161;
+			
+			// aapt resource value: 0x7F0E00E2
+			public const int TextAppearance_AppCompat_Small = 2131624162;
+			
+			// aapt resource value: 0x7F0E00E3
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131624163;
+			
+			// aapt resource value: 0x7F0E00E4
+			public const int TextAppearance_AppCompat_Subhead = 2131624164;
+			
+			// aapt resource value: 0x7F0E00E5
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131624165;
+			
+			// aapt resource value: 0x7F0E00E6
+			public const int TextAppearance_AppCompat_Title = 2131624166;
+			
+			// aapt resource value: 0x7F0E00E7
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131624167;
+			
+			// aapt resource value: 0x7F0E00E8
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131624168;
+			
+			// aapt resource value: 0x7F0E00E9
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131624169;
+			
+			// aapt resource value: 0x7F0E00EA
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131624170;
+			
+			// aapt resource value: 0x7F0E00EB
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131624171;
+			
+			// aapt resource value: 0x7F0E00EC
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131624172;
+			
+			// aapt resource value: 0x7F0E00ED
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131624173;
+			
+			// aapt resource value: 0x7F0E00EE
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131624174;
+			
+			// aapt resource value: 0x7F0E00EF
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131624175;
+			
+			// aapt resource value: 0x7F0E00F0
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131624176;
+			
+			// aapt resource value: 0x7F0E00F1
+			public const int TextAppearance_AppCompat_Widget_Button = 2131624177;
+			
+			// aapt resource value: 0x7F0E00F2
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131624178;
+			
+			// aapt resource value: 0x7F0E00F3
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131624179;
+			
+			// aapt resource value: 0x7F0E00F4
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131624180;
+			
+			// aapt resource value: 0x7F0E00F5
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131624181;
+			
+			// aapt resource value: 0x7F0E00F6
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131624182;
+			
+			// aapt resource value: 0x7F0E00F7
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131624183;
+			
+			// aapt resource value: 0x7F0E00F8
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131624184;
+			
+			// aapt resource value: 0x7F0E00F9
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131624185;
+			
+			// aapt resource value: 0x7F0E00FA
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131624186;
+			
+			// aapt resource value: 0x7F0E00FB
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131624187;
+			
+			// aapt resource value: 0x7F0E00FC
+			public const int TextAppearance_Design_Counter = 2131624188;
+			
+			// aapt resource value: 0x7F0E00FD
+			public const int TextAppearance_Design_Counter_Overflow = 2131624189;
+			
+			// aapt resource value: 0x7F0E00FE
+			public const int TextAppearance_Design_Error = 2131624190;
+			
+			// aapt resource value: 0x7F0E00FF
+			public const int TextAppearance_Design_Hint = 2131624191;
+			
+			// aapt resource value: 0x7F0E0100
+			public const int TextAppearance_Design_Snackbar_Message = 2131624192;
+			
+			// aapt resource value: 0x7F0E0101
+			public const int TextAppearance_Design_Tab = 2131624193;
+			
+			// aapt resource value: 0x7F0E0102
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131624194;
+			
+			// aapt resource value: 0x7F0E0103
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131624195;
+			
+			// aapt resource value: 0x7F0E0104
+			public const int TextAppearance_MediaRouter_Title = 2131624196;
+			
+			// aapt resource value: 0x7F0E0105
+			public const int TextAppearance_StatusBar_EventContent = 2131624197;
+			
+			// aapt resource value: 0x7F0E0106
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131624198;
+			
+			// aapt resource value: 0x7F0E0107
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131624199;
+			
+			// aapt resource value: 0x7F0E0108
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131624200;
+			
+			// aapt resource value: 0x7F0E0109
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131624201;
+			
+			// aapt resource value: 0x7F0E010A
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131624202;
+			
+			// aapt resource value: 0x7F0E010B
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131624203;
+			
+			// aapt resource value: 0x7F0E010C
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131624204;
+			
+			// aapt resource value: 0x7F0E012C
+			public const int ThemeOverlay_AppCompat = 2131624236;
+			
+			// aapt resource value: 0x7F0E012D
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131624237;
+			
+			// aapt resource value: 0x7F0E012E
+			public const int ThemeOverlay_AppCompat_Dark = 2131624238;
+			
+			// aapt resource value: 0x7F0E012F
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131624239;
+			
+			// aapt resource value: 0x7F0E0130
+			public const int ThemeOverlay_AppCompat_Dialog = 2131624240;
+			
+			// aapt resource value: 0x7F0E0131
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131624241;
+			
+			// aapt resource value: 0x7F0E0132
+			public const int ThemeOverlay_AppCompat_Light = 2131624242;
+			
+			// aapt resource value: 0x7F0E0133
+			public const int ThemeOverlay_MediaRouter_Dark = 2131624243;
+			
+			// aapt resource value: 0x7F0E0134
+			public const int ThemeOverlay_MediaRouter_Light = 2131624244;
+			
+			// aapt resource value: 0x7F0E010D
+			public const int Theme_AppCompat = 2131624205;
+			
+			// aapt resource value: 0x7F0E010E
+			public const int Theme_AppCompat_CompactMenu = 2131624206;
+			
+			// aapt resource value: 0x7F0E010F
+			public const int Theme_AppCompat_DayNight = 2131624207;
+			
+			// aapt resource value: 0x7F0E0110
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131624208;
+			
+			// aapt resource value: 0x7F0E0111
+			public const int Theme_AppCompat_DayNight_Dialog = 2131624209;
+			
+			// aapt resource value: 0x7F0E0114
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131624212;
+			
+			// aapt resource value: 0x7F0E0112
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131624210;
+			
+			// aapt resource value: 0x7F0E0113
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131624211;
+			
+			// aapt resource value: 0x7F0E0115
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131624213;
+			
+			// aapt resource value: 0x7F0E0116
+			public const int Theme_AppCompat_Dialog = 2131624214;
+			
+			// aapt resource value: 0x7F0E0119
+			public const int Theme_AppCompat_DialogWhenLarge = 2131624217;
+			
+			// aapt resource value: 0x7F0E0117
+			public const int Theme_AppCompat_Dialog_Alert = 2131624215;
+			
+			// aapt resource value: 0x7F0E0118
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131624216;
+			
+			// aapt resource value: 0x7F0E011A
+			public const int Theme_AppCompat_Light = 2131624218;
+			
+			// aapt resource value: 0x7F0E011B
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131624219;
+			
+			// aapt resource value: 0x7F0E011C
+			public const int Theme_AppCompat_Light_Dialog = 2131624220;
+			
+			// aapt resource value: 0x7F0E011F
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131624223;
+			
+			// aapt resource value: 0x7F0E011D
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131624221;
+			
+			// aapt resource value: 0x7F0E011E
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131624222;
+			
+			// aapt resource value: 0x7F0E0120
+			public const int Theme_AppCompat_Light_NoActionBar = 2131624224;
+			
+			// aapt resource value: 0x7F0E0121
+			public const int Theme_AppCompat_NoActionBar = 2131624225;
+			
+			// aapt resource value: 0x7F0E0122
+			public const int Theme_Design = 2131624226;
+			
+			// aapt resource value: 0x7F0E0123
+			public const int Theme_Design_BottomSheetDialog = 2131624227;
+			
+			// aapt resource value: 0x7F0E0124
+			public const int Theme_Design_Light = 2131624228;
+			
+			// aapt resource value: 0x7F0E0125
+			public const int Theme_Design_Light_BottomSheetDialog = 2131624229;
+			
+			// aapt resource value: 0x7F0E0126
+			public const int Theme_Design_Light_NoActionBar = 2131624230;
+			
+			// aapt resource value: 0x7F0E0127
+			public const int Theme_Design_NoActionBar = 2131624231;
+			
+			// aapt resource value: 0x7F0E0128
+			public const int Theme_MediaRouter = 2131624232;
+			
+			// aapt resource value: 0x7F0E0129
+			public const int Theme_MediaRouter_Light = 2131624233;
+			
+			// aapt resource value: 0x7F0E012B
+			public const int Theme_MediaRouter_LightControlPanel = 2131624235;
+			
+			// aapt resource value: 0x7F0E012A
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131624234;
+			
+			// aapt resource value: 0x7F0E0135
+			public const int Widget_AppCompat_ActionBar = 2131624245;
+			
+			// aapt resource value: 0x7F0E0136
+			public const int Widget_AppCompat_ActionBar_Solid = 2131624246;
+			
+			// aapt resource value: 0x7F0E0137
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131624247;
+			
+			// aapt resource value: 0x7F0E0138
+			public const int Widget_AppCompat_ActionBar_TabText = 2131624248;
+			
+			// aapt resource value: 0x7F0E0139
+			public const int Widget_AppCompat_ActionBar_TabView = 2131624249;
+			
+			// aapt resource value: 0x7F0E013A
+			public const int Widget_AppCompat_ActionButton = 2131624250;
+			
+			// aapt resource value: 0x7F0E013B
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131624251;
+			
+			// aapt resource value: 0x7F0E013C
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131624252;
+			
+			// aapt resource value: 0x7F0E013D
+			public const int Widget_AppCompat_ActionMode = 2131624253;
+			
+			// aapt resource value: 0x7F0E013E
+			public const int Widget_AppCompat_ActivityChooserView = 2131624254;
+			
+			// aapt resource value: 0x7F0E013F
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131624255;
+			
+			// aapt resource value: 0x7F0E0140
+			public const int Widget_AppCompat_Button = 2131624256;
+			
+			// aapt resource value: 0x7F0E0146
+			public const int Widget_AppCompat_ButtonBar = 2131624262;
+			
+			// aapt resource value: 0x7F0E0147
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131624263;
+			
+			// aapt resource value: 0x7F0E0141
+			public const int Widget_AppCompat_Button_Borderless = 2131624257;
+			
+			// aapt resource value: 0x7F0E0142
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131624258;
+			
+			// aapt resource value: 0x7F0E0143
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624259;
+			
+			// aapt resource value: 0x7F0E0144
+			public const int Widget_AppCompat_Button_Colored = 2131624260;
+			
+			// aapt resource value: 0x7F0E0145
+			public const int Widget_AppCompat_Button_Small = 2131624261;
+			
+			// aapt resource value: 0x7F0E0148
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131624264;
+			
+			// aapt resource value: 0x7F0E0149
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131624265;
+			
+			// aapt resource value: 0x7F0E014A
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131624266;
+			
+			// aapt resource value: 0x7F0E014B
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131624267;
+			
+			// aapt resource value: 0x7F0E014C
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131624268;
+			
+			// aapt resource value: 0x7F0E014D
+			public const int Widget_AppCompat_EditText = 2131624269;
+			
+			// aapt resource value: 0x7F0E014E
+			public const int Widget_AppCompat_ImageButton = 2131624270;
+			
+			// aapt resource value: 0x7F0E014F
+			public const int Widget_AppCompat_Light_ActionBar = 2131624271;
+			
+			// aapt resource value: 0x7F0E0150
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131624272;
+			
+			// aapt resource value: 0x7F0E0151
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131624273;
+			
+			// aapt resource value: 0x7F0E0152
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131624274;
+			
+			// aapt resource value: 0x7F0E0153
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131624275;
+			
+			// aapt resource value: 0x7F0E0154
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131624276;
+			
+			// aapt resource value: 0x7F0E0155
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624277;
+			
+			// aapt resource value: 0x7F0E0156
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131624278;
+			
+			// aapt resource value: 0x7F0E0157
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131624279;
+			
+			// aapt resource value: 0x7F0E0158
+			public const int Widget_AppCompat_Light_ActionButton = 2131624280;
+			
+			// aapt resource value: 0x7F0E0159
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131624281;
+			
+			// aapt resource value: 0x7F0E015A
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131624282;
+			
+			// aapt resource value: 0x7F0E015B
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131624283;
+			
+			// aapt resource value: 0x7F0E015C
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131624284;
+			
+			// aapt resource value: 0x7F0E015D
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131624285;
+			
+			// aapt resource value: 0x7F0E015E
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131624286;
+			
+			// aapt resource value: 0x7F0E015F
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131624287;
+			
+			// aapt resource value: 0x7F0E0160
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131624288;
+			
+			// aapt resource value: 0x7F0E0161
+			public const int Widget_AppCompat_Light_PopupMenu = 2131624289;
+			
+			// aapt resource value: 0x7F0E0162
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131624290;
+			
+			// aapt resource value: 0x7F0E0163
+			public const int Widget_AppCompat_Light_SearchView = 2131624291;
+			
+			// aapt resource value: 0x7F0E0164
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131624292;
+			
+			// aapt resource value: 0x7F0E0165
+			public const int Widget_AppCompat_ListMenuView = 2131624293;
+			
+			// aapt resource value: 0x7F0E0166
+			public const int Widget_AppCompat_ListPopupWindow = 2131624294;
+			
+			// aapt resource value: 0x7F0E0167
+			public const int Widget_AppCompat_ListView = 2131624295;
+			
+			// aapt resource value: 0x7F0E0168
+			public const int Widget_AppCompat_ListView_DropDown = 2131624296;
+			
+			// aapt resource value: 0x7F0E0169
+			public const int Widget_AppCompat_ListView_Menu = 2131624297;
+			
+			// aapt resource value: 0x7F0E016A
+			public const int Widget_AppCompat_NotificationActionContainer = 2131624298;
+			
+			// aapt resource value: 0x7F0E016B
+			public const int Widget_AppCompat_NotificationActionText = 2131624299;
+			
+			// aapt resource value: 0x7F0E016C
+			public const int Widget_AppCompat_PopupMenu = 2131624300;
+			
+			// aapt resource value: 0x7F0E016D
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131624301;
+			
+			// aapt resource value: 0x7F0E016E
+			public const int Widget_AppCompat_PopupWindow = 2131624302;
+			
+			// aapt resource value: 0x7F0E016F
+			public const int Widget_AppCompat_ProgressBar = 2131624303;
+			
+			// aapt resource value: 0x7F0E0170
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131624304;
+			
+			// aapt resource value: 0x7F0E0171
+			public const int Widget_AppCompat_RatingBar = 2131624305;
+			
+			// aapt resource value: 0x7F0E0172
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131624306;
+			
+			// aapt resource value: 0x7F0E0173
+			public const int Widget_AppCompat_RatingBar_Small = 2131624307;
+			
+			// aapt resource value: 0x7F0E0174
+			public const int Widget_AppCompat_SearchView = 2131624308;
+			
+			// aapt resource value: 0x7F0E0175
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131624309;
+			
+			// aapt resource value: 0x7F0E0176
+			public const int Widget_AppCompat_SeekBar = 2131624310;
+			
+			// aapt resource value: 0x7F0E0177
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131624311;
+			
+			// aapt resource value: 0x7F0E0178
+			public const int Widget_AppCompat_Spinner = 2131624312;
+			
+			// aapt resource value: 0x7F0E0179
+			public const int Widget_AppCompat_Spinner_DropDown = 2131624313;
+			
+			// aapt resource value: 0x7F0E017A
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131624314;
+			
+			// aapt resource value: 0x7F0E017B
+			public const int Widget_AppCompat_Spinner_Underlined = 2131624315;
+			
+			// aapt resource value: 0x7F0E017C
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131624316;
+			
+			// aapt resource value: 0x7F0E017D
+			public const int Widget_AppCompat_Toolbar = 2131624317;
+			
+			// aapt resource value: 0x7F0E017E
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131624318;
+			
+			// aapt resource value: 0x7F0E017F
+			public const int Widget_Design_AppBarLayout = 2131624319;
+			
+			// aapt resource value: 0x7F0E0180
+			public const int Widget_Design_BottomNavigationView = 2131624320;
+			
+			// aapt resource value: 0x7F0E0181
+			public const int Widget_Design_BottomSheet_Modal = 2131624321;
+			
+			// aapt resource value: 0x7F0E0182
+			public const int Widget_Design_CollapsingToolbar = 2131624322;
+			
+			// aapt resource value: 0x7F0E0183
+			public const int Widget_Design_CoordinatorLayout = 2131624323;
+			
+			// aapt resource value: 0x7F0E0184
+			public const int Widget_Design_FloatingActionButton = 2131624324;
+			
+			// aapt resource value: 0x7F0E0185
+			public const int Widget_Design_NavigationView = 2131624325;
+			
+			// aapt resource value: 0x7F0E0186
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131624326;
+			
+			// aapt resource value: 0x7F0E0187
+			public const int Widget_Design_Snackbar = 2131624327;
+			
+			// aapt resource value: 0x7F0E0188
+			public const int Widget_Design_TabLayout = 2131624328;
+			
+			// aapt resource value: 0x7F0E0189
+			public const int Widget_Design_TextInputLayout = 2131624329;
+			
+			// aapt resource value: 0x7F0E018A
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131624330;
+			
+			// aapt resource value: 0x7F0E018B
+			public const int Widget_MediaRouter_MediaRouteButton = 2131624331;
 			
 			static Style()
 			{
@@ -143,6 +5030,2040 @@ namespace Features.Forms.Droid
 			}
 			
 			private Style()
+			{
+			}
+		}
+		
+		public partial class Styleable
+		{
+			
+			// aapt resource value: { 0x7F03002B,0x7F03002C,0x7F03002D,0x7F03005E,0x7F03005F,0x7F030060,0x7F030061,0x7F030062,0x7F030063,0x7F03006F,0x7F030073,0x7F030074,0x7F03007F,0x7F030091,0x7F030092,0x7F030096,0x7F030097,0x7F030098,0x7F03009B,0x7F0300A1,0x7F0300BC,0x7F0300D1,0x7F0300E0,0x7F0300E4,0x7F0300E5,0x7F030109,0x7F03010C,0x7F030138,0x7F030142 }
+			public static int[] ActionBar = new int[] {
+					2130903083,
+					2130903084,
+					2130903085,
+					2130903134,
+					2130903135,
+					2130903136,
+					2130903137,
+					2130903138,
+					2130903139,
+					2130903151,
+					2130903155,
+					2130903156,
+					2130903167,
+					2130903185,
+					2130903186,
+					2130903190,
+					2130903191,
+					2130903192,
+					2130903195,
+					2130903201,
+					2130903228,
+					2130903249,
+					2130903264,
+					2130903268,
+					2130903269,
+					2130903305,
+					2130903308,
+					2130903352,
+					2130903362};
+			
+			// aapt resource value: { 0x10100B3 }
+			public static int[] ActionBarLayout = new int[] {
+					16842931};
+			
+			// aapt resource value: 0
+			public const int ActionBarLayout_android_layout_gravity = 0;
+			
+			// aapt resource value: 0
+			public const int ActionBar_background = 0;
+			
+			// aapt resource value: 1
+			public const int ActionBar_backgroundSplit = 1;
+			
+			// aapt resource value: 2
+			public const int ActionBar_backgroundStacked = 2;
+			
+			// aapt resource value: 3
+			public const int ActionBar_contentInsetEnd = 3;
+			
+			// aapt resource value: 4
+			public const int ActionBar_contentInsetEndWithActions = 4;
+			
+			// aapt resource value: 5
+			public const int ActionBar_contentInsetLeft = 5;
+			
+			// aapt resource value: 6
+			public const int ActionBar_contentInsetRight = 6;
+			
+			// aapt resource value: 7
+			public const int ActionBar_contentInsetStart = 7;
+			
+			// aapt resource value: 8
+			public const int ActionBar_contentInsetStartWithNavigation = 8;
+			
+			// aapt resource value: 9
+			public const int ActionBar_customNavigationLayout = 9;
+			
+			// aapt resource value: 10
+			public const int ActionBar_displayOptions = 10;
+			
+			// aapt resource value: 11
+			public const int ActionBar_divider = 11;
+			
+			// aapt resource value: 12
+			public const int ActionBar_elevation = 12;
+			
+			// aapt resource value: 13
+			public const int ActionBar_height = 13;
+			
+			// aapt resource value: 14
+			public const int ActionBar_hideOnContentScroll = 14;
+			
+			// aapt resource value: 15
+			public const int ActionBar_homeAsUpIndicator = 15;
+			
+			// aapt resource value: 16
+			public const int ActionBar_homeLayout = 16;
+			
+			// aapt resource value: 17
+			public const int ActionBar_icon = 17;
+			
+			// aapt resource value: 18
+			public const int ActionBar_indeterminateProgressStyle = 18;
+			
+			// aapt resource value: 19
+			public const int ActionBar_itemPadding = 19;
+			
+			// aapt resource value: 20
+			public const int ActionBar_logo = 20;
+			
+			// aapt resource value: 21
+			public const int ActionBar_navigationMode = 21;
+			
+			// aapt resource value: 22
+			public const int ActionBar_popupTheme = 22;
+			
+			// aapt resource value: 23
+			public const int ActionBar_progressBarPadding = 23;
+			
+			// aapt resource value: 24
+			public const int ActionBar_progressBarStyle = 24;
+			
+			// aapt resource value: 25
+			public const int ActionBar_subtitle = 25;
+			
+			// aapt resource value: 26
+			public const int ActionBar_subtitleTextStyle = 26;
+			
+			// aapt resource value: 27
+			public const int ActionBar_title = 27;
+			
+			// aapt resource value: 28
+			public const int ActionBar_titleTextStyle = 28;
+			
+			// aapt resource value: { 0x101013F }
+			public static int[] ActionMenuItemView = new int[] {
+					16843071};
+			
+			// aapt resource value: 0
+			public const int ActionMenuItemView_android_minWidth = 0;
+			
+			// aapt resource value: { 0xFFFFFFFF }
+			public static int[] ActionMenuView = new int[] {
+					-1};
+			
+			// aapt resource value: { 0x7F03002B,0x7F03002C,0x7F03004E,0x7F030091,0x7F03010C,0x7F030142 }
+			public static int[] ActionMode = new int[] {
+					2130903083,
+					2130903084,
+					2130903118,
+					2130903185,
+					2130903308,
+					2130903362};
+			
+			// aapt resource value: 0
+			public const int ActionMode_background = 0;
+			
+			// aapt resource value: 1
+			public const int ActionMode_backgroundSplit = 1;
+			
+			// aapt resource value: 2
+			public const int ActionMode_closeItemLayout = 2;
+			
+			// aapt resource value: 3
+			public const int ActionMode_height = 3;
+			
+			// aapt resource value: 4
+			public const int ActionMode_subtitleTextStyle = 4;
+			
+			// aapt resource value: 5
+			public const int ActionMode_titleTextStyle = 5;
+			
+			// aapt resource value: { 0x7F030082,0x7F03009C }
+			public static int[] ActivityChooserView = new int[] {
+					2130903170,
+					2130903196};
+			
+			// aapt resource value: 0
+			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 0;
+			
+			// aapt resource value: 1
+			public const int ActivityChooserView_initialActivityCount = 1;
+			
+			// aapt resource value: { 0x10100F2,0x7F030040,0x7F0300B3,0x7F0300B4,0x7F0300CE,0x7F0300F9,0x7F0300FA }
+			public static int[] AlertDialog = new int[] {
+					16842994,
+					2130903104,
+					2130903219,
+					2130903220,
+					2130903246,
+					2130903289,
+					2130903290};
+			
+			// aapt resource value: 0
+			public const int AlertDialog_android_layout = 0;
+			
+			// aapt resource value: 1
+			public const int AlertDialog_buttonPanelSideLayout = 1;
+			
+			// aapt resource value: 2
+			public const int AlertDialog_listItemLayout = 2;
+			
+			// aapt resource value: 3
+			public const int AlertDialog_listLayout = 3;
+			
+			// aapt resource value: 4
+			public const int AlertDialog_multiChoiceItemLayout = 4;
+			
+			// aapt resource value: 5
+			public const int AlertDialog_showTitle = 5;
+			
+			// aapt resource value: 6
+			public const int AlertDialog_singleChoiceItemLayout = 6;
+			
+			// aapt resource value: { 0x10100D4,0x7F03007F,0x7F030083 }
+			public static int[] AppBarLayout = new int[] {
+					16842964,
+					2130903167,
+					2130903171};
+			
+			// aapt resource value: { 0x7F030103,0x7F030104 }
+			public static int[] AppBarLayoutStates = new int[] {
+					2130903299,
+					2130903300};
+			
+			// aapt resource value: 0
+			public const int AppBarLayoutStates_state_collapsed = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayoutStates_state_collapsible = 1;
+			
+			// aapt resource value: 0
+			public const int AppBarLayout_android_background = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int AppBarLayout_expanded = 2;
+			
+			// aapt resource value: { 0x7F0300AF,0x7F0300B0 }
+			public static int[] AppBarLayout_Layout = new int[] {
+					2130903215,
+					2130903216};
+			
+			// aapt resource value: 0
+			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayout_Layout_layout_scrollInterpolator = 1;
+			
+			// aapt resource value: { 0x1010119,0x7F030100,0x7F030136,0x7F030137 }
+			public static int[] AppCompatImageView = new int[] {
+					16843033,
+					2130903296,
+					2130903350,
+					2130903351};
+			
+			// aapt resource value: 0
+			public const int AppCompatImageView_android_src = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatImageView_srcCompat = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatImageView_tint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatImageView_tintMode = 3;
+			
+			// aapt resource value: { 0x1010142,0x7F030133,0x7F030134,0x7F030135 }
+			public static int[] AppCompatSeekBar = new int[] {
+					16843074,
+					2130903347,
+					2130903348,
+					2130903349};
+			
+			// aapt resource value: 0
+			public const int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			// aapt resource value: { 0x1010034,0x101016D,0x101016E,0x101016F,0x1010170,0x1010392,0x1010393 }
+			public static int[] AppCompatTextHelper = new int[] {
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public const int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTextHelper_android_textAppearance = 0;
+			
+			// aapt resource value: { 0x1010034,0x7F030122 }
+			public static int[] AppCompatTextView = new int[] {
+					16842804,
+					2130903330};
+			
+			// aapt resource value: 0
+			public const int AppCompatTextView_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextView_textAllCaps = 1;
+			
+			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002A,0x7F030037,0x7F03003A,0x7F03003B,0x7F03003C,0x7F03003D,0x7F03003E,0x7F030041,0x7F030042,0x7F03004B,0x7F03004C,0x7F030054,0x7F030055,0x7F030056,0x7F030057,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03006A,0x7F030071,0x7F030072,0x7F030075,0x7F030077,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F03007E,0x7F030096,0x7F03009A,0x7F0300B1,0x7F0300B2,0x7F0300B5,0x7F0300B6,0x7F0300B7,0x7F0300B8,0x7F0300B9,0x7F0300BA,0x7F0300BB,0x7F0300D7,0x7F0300D8,0x7F0300D9,0x7F0300DF,0x7F0300E1,0x7F0300E8,0x7F0300E9,0x7F0300EA,0x7F0300EB,0x7F0300F2,0x7F0300F3,0x7F0300F4,0x7F0300F5,0x7F0300FD,0x7F0300FE,0x7F030110,0x7F030123,0x7F030124,0x7F030125,0x7F030126,0x7F030127,0x7F030128,0x7F030129,0x7F03012A,0x7F03012B,0x7F03012D,0x7F030144,0x7F030145,0x7F03014B,0x7F03014C,0x7F03014D,0x7F03014E,0x7F03014F,0x7F030150,0x7F030151,0x7F030152,0x7F030153,0x7F030154 }
+			public static int[] AppCompatTheme = new int[] {
+					16842839,
+					16842926,
+					2130903040,
+					2130903041,
+					2130903042,
+					2130903043,
+					2130903044,
+					2130903045,
+					2130903046,
+					2130903047,
+					2130903048,
+					2130903049,
+					2130903050,
+					2130903051,
+					2130903052,
+					2130903054,
+					2130903055,
+					2130903056,
+					2130903057,
+					2130903058,
+					2130903059,
+					2130903060,
+					2130903061,
+					2130903062,
+					2130903063,
+					2130903064,
+					2130903065,
+					2130903066,
+					2130903067,
+					2130903068,
+					2130903069,
+					2130903070,
+					2130903073,
+					2130903074,
+					2130903075,
+					2130903076,
+					2130903077,
+					2130903082,
+					2130903095,
+					2130903098,
+					2130903099,
+					2130903100,
+					2130903101,
+					2130903102,
+					2130903105,
+					2130903106,
+					2130903115,
+					2130903116,
+					2130903124,
+					2130903125,
+					2130903126,
+					2130903127,
+					2130903128,
+					2130903129,
+					2130903130,
+					2130903131,
+					2130903132,
+					2130903146,
+					2130903153,
+					2130903154,
+					2130903157,
+					2130903159,
+					2130903162,
+					2130903163,
+					2130903164,
+					2130903165,
+					2130903166,
+					2130903190,
+					2130903194,
+					2130903217,
+					2130903218,
+					2130903221,
+					2130903222,
+					2130903223,
+					2130903224,
+					2130903225,
+					2130903226,
+					2130903227,
+					2130903255,
+					2130903256,
+					2130903257,
+					2130903263,
+					2130903265,
+					2130903272,
+					2130903273,
+					2130903274,
+					2130903275,
+					2130903282,
+					2130903283,
+					2130903284,
+					2130903285,
+					2130903293,
+					2130903294,
+					2130903312,
+					2130903331,
+					2130903332,
+					2130903333,
+					2130903334,
+					2130903335,
+					2130903336,
+					2130903337,
+					2130903338,
+					2130903339,
+					2130903341,
+					2130903364,
+					2130903365,
+					2130903371,
+					2130903372,
+					2130903373,
+					2130903374,
+					2130903375,
+					2130903376,
+					2130903377,
+					2130903378,
+					2130903379,
+					2130903380};
+			
+			// aapt resource value: 2
+			public const int AppCompatTheme_actionBarDivider = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatTheme_actionBarItemBackground = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTheme_actionBarPopupTheme = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTheme_actionBarSize = 5;
+			
+			// aapt resource value: 6
+			public const int AppCompatTheme_actionBarSplitStyle = 6;
+			
+			// aapt resource value: 7
+			public const int AppCompatTheme_actionBarStyle = 7;
+			
+			// aapt resource value: 8
+			public const int AppCompatTheme_actionBarTabBarStyle = 8;
+			
+			// aapt resource value: 9
+			public const int AppCompatTheme_actionBarTabStyle = 9;
+			
+			// aapt resource value: 10
+			public const int AppCompatTheme_actionBarTabTextStyle = 10;
+			
+			// aapt resource value: 11
+			public const int AppCompatTheme_actionBarTheme = 11;
+			
+			// aapt resource value: 12
+			public const int AppCompatTheme_actionBarWidgetTheme = 12;
+			
+			// aapt resource value: 13
+			public const int AppCompatTheme_actionButtonStyle = 13;
+			
+			// aapt resource value: 14
+			public const int AppCompatTheme_actionDropDownStyle = 14;
+			
+			// aapt resource value: 15
+			public const int AppCompatTheme_actionMenuTextAppearance = 15;
+			
+			// aapt resource value: 16
+			public const int AppCompatTheme_actionMenuTextColor = 16;
+			
+			// aapt resource value: 17
+			public const int AppCompatTheme_actionModeBackground = 17;
+			
+			// aapt resource value: 18
+			public const int AppCompatTheme_actionModeCloseButtonStyle = 18;
+			
+			// aapt resource value: 19
+			public const int AppCompatTheme_actionModeCloseDrawable = 19;
+			
+			// aapt resource value: 20
+			public const int AppCompatTheme_actionModeCopyDrawable = 20;
+			
+			// aapt resource value: 21
+			public const int AppCompatTheme_actionModeCutDrawable = 21;
+			
+			// aapt resource value: 22
+			public const int AppCompatTheme_actionModeFindDrawable = 22;
+			
+			// aapt resource value: 23
+			public const int AppCompatTheme_actionModePasteDrawable = 23;
+			
+			// aapt resource value: 24
+			public const int AppCompatTheme_actionModePopupWindowStyle = 24;
+			
+			// aapt resource value: 25
+			public const int AppCompatTheme_actionModeSelectAllDrawable = 25;
+			
+			// aapt resource value: 26
+			public const int AppCompatTheme_actionModeShareDrawable = 26;
+			
+			// aapt resource value: 27
+			public const int AppCompatTheme_actionModeSplitBackground = 27;
+			
+			// aapt resource value: 28
+			public const int AppCompatTheme_actionModeStyle = 28;
+			
+			// aapt resource value: 29
+			public const int AppCompatTheme_actionModeWebSearchDrawable = 29;
+			
+			// aapt resource value: 30
+			public const int AppCompatTheme_actionOverflowButtonStyle = 30;
+			
+			// aapt resource value: 31
+			public const int AppCompatTheme_actionOverflowMenuStyle = 31;
+			
+			// aapt resource value: 32
+			public const int AppCompatTheme_activityChooserViewStyle = 32;
+			
+			// aapt resource value: 33
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 33;
+			
+			// aapt resource value: 34
+			public const int AppCompatTheme_alertDialogCenterButtons = 34;
+			
+			// aapt resource value: 35
+			public const int AppCompatTheme_alertDialogStyle = 35;
+			
+			// aapt resource value: 36
+			public const int AppCompatTheme_alertDialogTheme = 36;
+			
+			// aapt resource value: 1
+			public const int AppCompatTheme_android_windowAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTheme_android_windowIsFloating = 0;
+			
+			// aapt resource value: 37
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 37;
+			
+			// aapt resource value: 38
+			public const int AppCompatTheme_borderlessButtonStyle = 38;
+			
+			// aapt resource value: 39
+			public const int AppCompatTheme_buttonBarButtonStyle = 39;
+			
+			// aapt resource value: 40
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 40;
+			
+			// aapt resource value: 41
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 41;
+			
+			// aapt resource value: 42
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 42;
+			
+			// aapt resource value: 43
+			public const int AppCompatTheme_buttonBarStyle = 43;
+			
+			// aapt resource value: 44
+			public const int AppCompatTheme_buttonStyle = 44;
+			
+			// aapt resource value: 45
+			public const int AppCompatTheme_buttonStyleSmall = 45;
+			
+			// aapt resource value: 46
+			public const int AppCompatTheme_checkboxStyle = 46;
+			
+			// aapt resource value: 47
+			public const int AppCompatTheme_checkedTextViewStyle = 47;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_colorAccent = 48;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_colorBackgroundFloating = 49;
+			
+			// aapt resource value: 50
+			public const int AppCompatTheme_colorButtonNormal = 50;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_colorControlActivated = 51;
+			
+			// aapt resource value: 52
+			public const int AppCompatTheme_colorControlHighlight = 52;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_colorControlNormal = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_colorPrimary = 54;
+			
+			// aapt resource value: 55
+			public const int AppCompatTheme_colorPrimaryDark = 55;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_colorSwitchThumbNormal = 56;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_controlBackground = 57;
+			
+			// aapt resource value: 58
+			public const int AppCompatTheme_dialogPreferredPadding = 58;
+			
+			// aapt resource value: 59
+			public const int AppCompatTheme_dialogTheme = 59;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_dividerHorizontal = 60;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_dividerVertical = 61;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 63;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_dropDownListViewStyle = 62;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_editTextColor = 65;
+			
+			// aapt resource value: 66
+			public const int AppCompatTheme_editTextStyle = 66;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_homeAsUpIndicator = 67;
+			
+			// aapt resource value: 68
+			public const int AppCompatTheme_imageButtonStyle = 68;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 69;
+			
+			// aapt resource value: 70
+			public const int AppCompatTheme_listDividerAlertDialog = 70;
+			
+			// aapt resource value: 71
+			public const int AppCompatTheme_listMenuViewStyle = 71;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listPopupWindowStyle = 72;
+			
+			// aapt resource value: 73
+			public const int AppCompatTheme_listPreferredItemHeight = 73;
+			
+			// aapt resource value: 74
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 74;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 75;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 76;
+			
+			// aapt resource value: 77
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_panelBackground = 78;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_panelMenuListTheme = 79;
+			
+			// aapt resource value: 80
+			public const int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 81
+			public const int AppCompatTheme_popupMenuStyle = 81;
+			
+			// aapt resource value: 82
+			public const int AppCompatTheme_popupWindowStyle = 82;
+			
+			// aapt resource value: 83
+			public const int AppCompatTheme_radioButtonStyle = 83;
+			
+			// aapt resource value: 84
+			public const int AppCompatTheme_ratingBarStyle = 84;
+			
+			// aapt resource value: 85
+			public const int AppCompatTheme_ratingBarStyleIndicator = 85;
+			
+			// aapt resource value: 86
+			public const int AppCompatTheme_ratingBarStyleSmall = 86;
+			
+			// aapt resource value: 87
+			public const int AppCompatTheme_searchViewStyle = 87;
+			
+			// aapt resource value: 88
+			public const int AppCompatTheme_seekBarStyle = 88;
+			
+			// aapt resource value: 89
+			public const int AppCompatTheme_selectableItemBackground = 89;
+			
+			// aapt resource value: 90
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 90;
+			
+			// aapt resource value: 91
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 91;
+			
+			// aapt resource value: 92
+			public const int AppCompatTheme_spinnerStyle = 92;
+			
+			// aapt resource value: 93
+			public const int AppCompatTheme_switchStyle = 93;
+			
+			// aapt resource value: 94
+			public const int AppCompatTheme_textAppearanceLargePopupMenu = 94;
+			
+			// aapt resource value: 95
+			public const int AppCompatTheme_textAppearanceListItem = 95;
+			
+			// aapt resource value: 96
+			public const int AppCompatTheme_textAppearanceListItemSecondary = 96;
+			
+			// aapt resource value: 97
+			public const int AppCompatTheme_textAppearanceListItemSmall = 97;
+			
+			// aapt resource value: 98
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 98;
+			
+			// aapt resource value: 99
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 99;
+			
+			// aapt resource value: 100
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 100;
+			
+			// aapt resource value: 101
+			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 101;
+			
+			// aapt resource value: 102
+			public const int AppCompatTheme_textColorAlertDialogListItem = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_textColorSearchUrl = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_toolbarStyle = 105;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_windowActionBar = 106;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_windowActionBarOverlay = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_windowActionModeOverlay = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_windowFixedHeightMajor = 109;
+			
+			// aapt resource value: 110
+			public const int AppCompatTheme_windowFixedHeightMinor = 110;
+			
+			// aapt resource value: 111
+			public const int AppCompatTheme_windowFixedWidthMajor = 111;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_windowFixedWidthMinor = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_windowMinWidthMajor = 113;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_windowMinWidthMinor = 114;
+			
+			// aapt resource value: 115
+			public const int AppCompatTheme_windowNoTitle = 115;
+			
+			// aapt resource value: { 0x7F03007F,0x7F03009F,0x7F0300A0,0x7F0300A3,0x7F0300CD }
+			public static int[] BottomNavigationView = new int[] {
+					2130903167,
+					2130903199,
+					2130903200,
+					2130903203,
+					2130903245};
+			
+			// aapt resource value: 0
+			public const int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 1
+			public const int BottomNavigationView_itemBackground = 1;
+			
+			// aapt resource value: 2
+			public const int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public const int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 4
+			public const int BottomNavigationView_menu = 4;
+			
+			// aapt resource value: { 0x7F030032,0x7F030034,0x7F030035 }
+			public static int[] BottomSheetBehavior_Layout = new int[] {
+					2130903090,
+					2130903092,
+					2130903093};
+			
+			// aapt resource value: 0
+			public const int BottomSheetBehavior_Layout_behavior_hideable = 0;
+			
+			// aapt resource value: 1
+			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 1;
+			
+			// aapt resource value: 2
+			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
+			
+			// aapt resource value: { 0x7F030026 }
+			public static int[] ButtonBarLayout = new int[] {
+					2130903078};
+			
+			// aapt resource value: 0
+			public const int ButtonBarLayout_allowStacking = 0;
+			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F030064,0x7F030065,0x7F030066,0x7F030067,0x7F030068 }
+			public static int[] CardView = new int[] {
+					16843071,
+					16843072,
+					2130903109,
+					2130903110,
+					2130903111,
+					2130903112,
+					2130903113,
+					2130903114,
+					2130903140,
+					2130903141,
+					2130903142,
+					2130903143,
+					2130903144};
+			
+			// aapt resource value: 1
+			public const int CardView_android_minHeight = 1;
+			
+			// aapt resource value: 0
+			public const int CardView_android_minWidth = 0;
+			
+			// aapt resource value: 2
+			public const int CardView_cardBackgroundColor = 2;
+			
+			// aapt resource value: 3
+			public const int CardView_cardCornerRadius = 3;
+			
+			// aapt resource value: 4
+			public const int CardView_cardElevation = 4;
+			
+			// aapt resource value: 5
+			public const int CardView_cardMaxElevation = 5;
+			
+			// aapt resource value: 6
+			public const int CardView_cardPreventCornerOverlap = 6;
+			
+			// aapt resource value: 7
+			public const int CardView_cardUseCompatPadding = 7;
+			
+			// aapt resource value: 8
+			public const int CardView_contentPadding = 8;
+			
+			// aapt resource value: 9
+			public const int CardView_contentPaddingBottom = 9;
+			
+			// aapt resource value: 10
+			public const int CardView_contentPaddingLeft = 10;
+			
+			// aapt resource value: 11
+			public const int CardView_contentPaddingRight = 11;
+			
+			// aapt resource value: 12
+			public const int CardView_contentPaddingTop = 12;
+			
+			// aapt resource value: { 0x7F030051,0x7F030052,0x7F030069,0x7F030084,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F0300EE,0x7F0300EF,0x7F030106,0x7F030138,0x7F030139,0x7F030143 }
+			public static int[] CollapsingToolbarLayout = new int[] {
+					2130903121,
+					2130903122,
+					2130903145,
+					2130903172,
+					2130903173,
+					2130903174,
+					2130903175,
+					2130903176,
+					2130903177,
+					2130903178,
+					2130903278,
+					2130903279,
+					2130903302,
+					2130903352,
+					2130903353,
+					2130903363};
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 0;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 1;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_contentScrim = 2;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 3;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 4;
+			
+			// aapt resource value: 5
+			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 6
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 6;
+			
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 7;
+			
+			// aapt resource value: 8
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 8;
+			
+			// aapt resource value: 9
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 9;
+			
+			// aapt resource value: { 0x7F0300AA,0x7F0300AB }
+			public static int[] CollapsingToolbarLayout_Layout = new int[] {
+					2130903210,
+					2130903211};
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			// aapt resource value: 10
+			public const int CollapsingToolbarLayout_scrimAnimationDuration = 10;
+			
+			// aapt resource value: 11
+			public const int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
+			
+			// aapt resource value: 12
+			public const int CollapsingToolbarLayout_statusBarScrim = 12;
+			
+			// aapt resource value: 13
+			public const int CollapsingToolbarLayout_title = 13;
+			
+			// aapt resource value: 14
+			public const int CollapsingToolbarLayout_titleEnabled = 14;
+			
+			// aapt resource value: 15
+			public const int CollapsingToolbarLayout_toolbarId = 15;
+			
+			// aapt resource value: { 0x10101A5,0x101031F,0x7F030027 }
+			public static int[] ColorStateListItem = new int[] {
+					16843173,
+					16843551,
+					2130903079};
+			
+			// aapt resource value: 2
+			public const int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public const int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public const int ColorStateListItem_android_color = 0;
+			
+			// aapt resource value: { 0x1010107,0x7F030043,0x7F030044 }
+			public static int[] CompoundButton = new int[] {
+					16843015,
+					2130903107,
+					2130903108};
+			
+			// aapt resource value: 0
+			public const int CompoundButton_android_button = 0;
+			
+			// aapt resource value: 1
+			public const int CompoundButton_buttonTint = 1;
+			
+			// aapt resource value: 2
+			public const int CompoundButton_buttonTintMode = 2;
+			
+			// aapt resource value: { 0x7F0300A4,0x7F030105 }
+			public static int[] CoordinatorLayout = new int[] {
+					2130903204,
+					2130903301};
+			
+			// aapt resource value: 0
+			public const int CoordinatorLayout_keylines = 0;
+			
+			// aapt resource value: { 0x10100B3,0x7F0300A7,0x7F0300A8,0x7F0300A9,0x7F0300AC,0x7F0300AD,0x7F0300AE }
+			public static int[] CoordinatorLayout_Layout = new int[] {
+					16842931,
+					2130903207,
+					2130903208,
+					2130903209,
+					2130903212,
+					2130903213,
+					2130903214};
+			
+			// aapt resource value: 0
+			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
+			
+			// aapt resource value: 1
+			public const int CoordinatorLayout_Layout_layout_anchor = 1;
+			
+			// aapt resource value: 2
+			public const int CoordinatorLayout_Layout_layout_anchorGravity = 2;
+			
+			// aapt resource value: 3
+			public const int CoordinatorLayout_Layout_layout_behavior = 3;
+			
+			// aapt resource value: 4
+			public const int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 4;
+			
+			// aapt resource value: 5
+			public const int CoordinatorLayout_Layout_layout_insetEdge = 5;
+			
+			// aapt resource value: 6
+			public const int CoordinatorLayout_Layout_layout_keyline = 6;
+			
+			// aapt resource value: 1
+			public const int CoordinatorLayout_statusBarBackground = 1;
+			
+			// aapt resource value: { 0x7F030038,0x7F030039,0x7F03012C }
+			public static int[] DesignTheme = new int[] {
+					2130903096,
+					2130903097,
+					2130903340};
+			
+			// aapt resource value: 0
+			public const int DesignTheme_bottomSheetDialogTheme = 0;
+			
+			// aapt resource value: 1
+			public const int DesignTheme_bottomSheetStyle = 1;
+			
+			// aapt resource value: 2
+			public const int DesignTheme_textColorError = 2;
+			
+			// aapt resource value: { 0x7F030028,0x7F030029,0x7F030030,0x7F030053,0x7F030078,0x7F03008E,0x7F0300FC,0x7F03012F }
+			public static int[] DrawerArrowToggle = new int[] {
+					2130903080,
+					2130903081,
+					2130903088,
+					2130903123,
+					2130903160,
+					2130903182,
+					2130903292,
+					2130903343};
+			
+			// aapt resource value: 0
+			public const int DrawerArrowToggle_arrowHeadLength = 0;
+			
+			// aapt resource value: 1
+			public const int DrawerArrowToggle_arrowShaftLength = 1;
+			
+			// aapt resource value: 2
+			public const int DrawerArrowToggle_barLength = 2;
+			
+			// aapt resource value: 3
+			public const int DrawerArrowToggle_color = 3;
+			
+			// aapt resource value: 4
+			public const int DrawerArrowToggle_drawableSize = 4;
+			
+			// aapt resource value: 5
+			public const int DrawerArrowToggle_gapBetweenBars = 5;
+			
+			// aapt resource value: 6
+			public const int DrawerArrowToggle_spinBars = 6;
+			
+			// aapt resource value: 7
+			public const int DrawerArrowToggle_thickness = 7;
+			
+			// aapt resource value: { 0x7F03002E,0x7F03002F,0x7F030036,0x7F03007F,0x7F03008C,0x7F0300E3,0x7F0300ED,0x7F030149 }
+			public static int[] FloatingActionButton = new int[] {
+					2130903086,
+					2130903087,
+					2130903094,
+					2130903167,
+					2130903180,
+					2130903267,
+					2130903277,
+					2130903369};
+			
+			// aapt resource value: 0
+			public const int FloatingActionButton_backgroundTint = 0;
+			
+			// aapt resource value: 1
+			public const int FloatingActionButton_backgroundTintMode = 1;
+			
+			// aapt resource value: { 0x7F030031 }
+			public static int[] FloatingActionButton_Behavior_Layout = new int[] {
+					2130903089};
+			
+			// aapt resource value: 0
+			public const int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
+			
+			// aapt resource value: 2
+			public const int FloatingActionButton_borderWidth = 2;
+			
+			// aapt resource value: 3
+			public const int FloatingActionButton_elevation = 3;
+			
+			// aapt resource value: 4
+			public const int FloatingActionButton_fabSize = 4;
+			
+			// aapt resource value: 5
+			public const int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 6
+			public const int FloatingActionButton_rippleColor = 6;
+			
+			// aapt resource value: 7
+			public const int FloatingActionButton_useCompatPadding = 7;
+			
+			// aapt resource value: { 0x1010109,0x1010200,0x7F03008D }
+			public static int[] ForegroundLinearLayout = new int[] {
+					16843017,
+					16843264,
+					2130903181};
+			
+			// aapt resource value: 0
+			public const int ForegroundLinearLayout_android_foreground = 0;
+			
+			// aapt resource value: 1
+			public const int ForegroundLinearLayout_android_foregroundGravity = 1;
+			
+			// aapt resource value: 2
+			public const int ForegroundLinearLayout_foregroundInsidePadding = 2;
+			
+			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F030074,0x7F030076,0x7F0300C0,0x7F0300F7 }
+			public static int[] LinearLayoutCompat = new int[] {
+					16842927,
+					16842948,
+					16843046,
+					16843047,
+					16843048,
+					2130903156,
+					2130903158,
+					2130903232,
+					2130903287};
+			
+			// aapt resource value: 2
+			public const int LinearLayoutCompat_android_baselineAligned = 2;
+			
+			// aapt resource value: 3
+			public const int LinearLayoutCompat_android_baselineAlignedChildIndex = 3;
+			
+			// aapt resource value: 0
+			public const int LinearLayoutCompat_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public const int LinearLayoutCompat_android_orientation = 1;
+			
+			// aapt resource value: 4
+			public const int LinearLayoutCompat_android_weightSum = 4;
+			
+			// aapt resource value: 5
+			public const int LinearLayoutCompat_divider = 5;
+			
+			// aapt resource value: 6
+			public const int LinearLayoutCompat_dividerPadding = 6;
+			
+			// aapt resource value: { 0x10100B3,0x10100F4,0x10100F5,0x1010181 }
+			public static int[] LinearLayoutCompat_Layout = new int[] {
+					16842931,
+					16842996,
+					16842997,
+					16843137};
+			
+			// aapt resource value: 0
+			public const int LinearLayoutCompat_Layout_android_layout_gravity = 0;
+			
+			// aapt resource value: 2
+			public const int LinearLayoutCompat_Layout_android_layout_height = 2;
+			
+			// aapt resource value: 3
+			public const int LinearLayoutCompat_Layout_android_layout_weight = 3;
+			
+			// aapt resource value: 1
+			public const int LinearLayoutCompat_Layout_android_layout_width = 1;
+			
+			// aapt resource value: 7
+			public const int LinearLayoutCompat_measureWithLargestChild = 7;
+			
+			// aapt resource value: 8
+			public const int LinearLayoutCompat_showDividers = 8;
+			
+			// aapt resource value: { 0x10102AC,0x10102AD }
+			public static int[] ListPopupWindow = new int[] {
+					16843436,
+					16843437};
+			
+			// aapt resource value: 0
+			public const int ListPopupWindow_android_dropDownHorizontalOffset = 0;
+			
+			// aapt resource value: 1
+			public const int ListPopupWindow_android_dropDownVerticalOffset = 1;
+			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030043,0x7F03008B }
+			public static int[] MediaRouteButton = new int[] {
+					16843071,
+					16843072,
+					2130903107,
+					2130903179};
+			
+			// aapt resource value: 1
+			public const int MediaRouteButton_android_minHeight = 1;
+			
+			// aapt resource value: 0
+			public const int MediaRouteButton_android_minWidth = 0;
+			
+			// aapt resource value: 2
+			public const int MediaRouteButton_buttonTint = 2;
+			
+			// aapt resource value: 3
+			public const int MediaRouteButton_externalRouteEnabledDrawable = 3;
+			
+			// aapt resource value: { 0x101000E,0x10100D0,0x1010194,0x10101DE,0x10101DF,0x10101E0 }
+			public static int[] MenuGroup = new int[] {
+					16842766,
+					16842960,
+					16843156,
+					16843230,
+					16843231,
+					16843232};
+			
+			// aapt resource value: 5
+			public const int MenuGroup_android_checkableBehavior = 5;
+			
+			// aapt resource value: 0
+			public const int MenuGroup_android_enabled = 0;
+			
+			// aapt resource value: 1
+			public const int MenuGroup_android_id = 1;
+			
+			// aapt resource value: 3
+			public const int MenuGroup_android_menuCategory = 3;
+			
+			// aapt resource value: 4
+			public const int MenuGroup_android_orderInCategory = 4;
+			
+			// aapt resource value: 2
+			public const int MenuGroup_android_visible = 2;
+			
+			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F0300F6 }
+			public static int[] MenuItem = new int[] {
+					16842754,
+					16842766,
+					16842960,
+					16843014,
+					16843156,
+					16843230,
+					16843231,
+					16843233,
+					16843234,
+					16843235,
+					16843236,
+					16843237,
+					16843375,
+					2130903053,
+					2130903071,
+					2130903072,
+					2130903286};
+			
+			// aapt resource value: 13
+			public const int MenuItem_actionLayout = 13;
+			
+			// aapt resource value: 14
+			public const int MenuItem_actionProviderClass = 14;
+			
+			// aapt resource value: 15
+			public const int MenuItem_actionViewClass = 15;
+			
+			// aapt resource value: 9
+			public const int MenuItem_android_alphabeticShortcut = 9;
+			
+			// aapt resource value: 11
+			public const int MenuItem_android_checkable = 11;
+			
+			// aapt resource value: 3
+			public const int MenuItem_android_checked = 3;
+			
+			// aapt resource value: 1
+			public const int MenuItem_android_enabled = 1;
+			
+			// aapt resource value: 0
+			public const int MenuItem_android_icon = 0;
+			
+			// aapt resource value: 2
+			public const int MenuItem_android_id = 2;
+			
+			// aapt resource value: 5
+			public const int MenuItem_android_menuCategory = 5;
+			
+			// aapt resource value: 10
+			public const int MenuItem_android_numericShortcut = 10;
+			
+			// aapt resource value: 12
+			public const int MenuItem_android_onClick = 12;
+			
+			// aapt resource value: 6
+			public const int MenuItem_android_orderInCategory = 6;
+			
+			// aapt resource value: 7
+			public const int MenuItem_android_title = 7;
+			
+			// aapt resource value: 8
+			public const int MenuItem_android_titleCondensed = 8;
+			
+			// aapt resource value: 4
+			public const int MenuItem_android_visible = 4;
+			
+			// aapt resource value: 16
+			public const int MenuItem_showAsAction = 16;
+			
+			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F0300E2,0x7F030107 }
+			public static int[] MenuView = new int[] {
+					16842926,
+					16843052,
+					16843053,
+					16843054,
+					16843055,
+					16843056,
+					16843057,
+					2130903266,
+					2130903303};
+			
+			// aapt resource value: 4
+			public const int MenuView_android_headerBackground = 4;
+			
+			// aapt resource value: 2
+			public const int MenuView_android_horizontalDivider = 2;
+			
+			// aapt resource value: 5
+			public const int MenuView_android_itemBackground = 5;
+			
+			// aapt resource value: 6
+			public const int MenuView_android_itemIconDisabledAlpha = 6;
+			
+			// aapt resource value: 1
+			public const int MenuView_android_itemTextAppearance = 1;
+			
+			// aapt resource value: 3
+			public const int MenuView_android_verticalDivider = 3;
+			
+			// aapt resource value: 0
+			public const int MenuView_android_windowAnimationStyle = 0;
+			
+			// aapt resource value: 7
+			public const int MenuView_preserveIconSpacing = 7;
+			
+			// aapt resource value: 8
+			public const int MenuView_subMenuArrow = 8;
+			
+			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F03007F,0x7F030090,0x7F03009F,0x7F0300A0,0x7F0300A2,0x7F0300A3,0x7F0300CD }
+			public static int[] NavigationView = new int[] {
+					16842964,
+					16842973,
+					16843039,
+					2130903167,
+					2130903184,
+					2130903199,
+					2130903200,
+					2130903202,
+					2130903203,
+					2130903245};
+			
+			// aapt resource value: 0
+			public const int NavigationView_android_background = 0;
+			
+			// aapt resource value: 1
+			public const int NavigationView_android_fitsSystemWindows = 1;
+			
+			// aapt resource value: 2
+			public const int NavigationView_android_maxWidth = 2;
+			
+			// aapt resource value: 3
+			public const int NavigationView_elevation = 3;
+			
+			// aapt resource value: 4
+			public const int NavigationView_headerLayout = 4;
+			
+			// aapt resource value: 5
+			public const int NavigationView_itemBackground = 5;
+			
+			// aapt resource value: 6
+			public const int NavigationView_itemIconTint = 6;
+			
+			// aapt resource value: 7
+			public const int NavigationView_itemTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public const int NavigationView_itemTextColor = 8;
+			
+			// aapt resource value: 9
+			public const int NavigationView_menu = 9;
+			
+			// aapt resource value: { 0x1010176,0x10102C9,0x7F0300D2 }
+			public static int[] PopupWindow = new int[] {
+					16843126,
+					16843465,
+					2130903250};
+			
+			// aapt resource value: { 0x7F030102 }
+			public static int[] PopupWindowBackgroundState = new int[] {
+					2130903298};
+			
+			// aapt resource value: 0
+			public const int PopupWindowBackgroundState_state_above_anchor = 0;
+			
+			// aapt resource value: 1
+			public const int PopupWindow_android_popupAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public const int PopupWindow_android_popupBackground = 0;
+			
+			// aapt resource value: 2
+			public const int PopupWindow_overlapAnchor = 2;
+			
+			// aapt resource value: { 0x7F0300D3,0x7F0300D6 }
+			public static int[] RecycleListView = new int[] {
+					2130903251,
+					2130903254};
+			
+			// aapt resource value: 0
+			public const int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public const int RecycleListView_paddingTopNoTitle = 1;
+			
+			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300A6,0x7F0300EC,0x7F0300FB,0x7F030101 }
+			public static int[] RecyclerView = new int[] {
+					16842948,
+					16842993,
+					2130903206,
+					2130903276,
+					2130903291,
+					2130903297};
+			
+			// aapt resource value: 1
+			public const int RecyclerView_android_descendantFocusability = 1;
+			
+			// aapt resource value: 0
+			public const int RecyclerView_android_orientation = 0;
+			
+			// aapt resource value: 2
+			public const int RecyclerView_layoutManager = 2;
+			
+			// aapt resource value: 3
+			public const int RecyclerView_reverseLayout = 3;
+			
+			// aapt resource value: 4
+			public const int RecyclerView_spanCount = 4;
+			
+			// aapt resource value: 5
+			public const int RecyclerView_stackFromEnd = 5;
+			
+			// aapt resource value: { 0x7F03009D }
+			public static int[] ScrimInsetsFrameLayout = new int[] {
+					2130903197};
+			
+			// aapt resource value: 0
+			public const int ScrimInsetsFrameLayout_insetForeground = 0;
+			
+			// aapt resource value: { 0x7F030033 }
+			public static int[] ScrollingViewBehavior_Layout = new int[] {
+					2130903091};
+			
+			// aapt resource value: 0
+			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
+			
+			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F03004D,0x7F03005D,0x7F030070,0x7F03008F,0x7F030099,0x7F0300A5,0x7F0300E6,0x7F0300E7,0x7F0300F0,0x7F0300F1,0x7F030108,0x7F03010D,0x7F03014A }
+			public static int[] SearchView = new int[] {
+					16842970,
+					16843039,
+					16843296,
+					16843364,
+					2130903117,
+					2130903133,
+					2130903152,
+					2130903183,
+					2130903193,
+					2130903205,
+					2130903270,
+					2130903271,
+					2130903280,
+					2130903281,
+					2130903304,
+					2130903309,
+					2130903370};
+			
+			// aapt resource value: 0
+			public const int SearchView_android_focusable = 0;
+			
+			// aapt resource value: 3
+			public const int SearchView_android_imeOptions = 3;
+			
+			// aapt resource value: 2
+			public const int SearchView_android_inputType = 2;
+			
+			// aapt resource value: 1
+			public const int SearchView_android_maxWidth = 1;
+			
+			// aapt resource value: 4
+			public const int SearchView_closeIcon = 4;
+			
+			// aapt resource value: 5
+			public const int SearchView_commitIcon = 5;
+			
+			// aapt resource value: 6
+			public const int SearchView_defaultQueryHint = 6;
+			
+			// aapt resource value: 7
+			public const int SearchView_goIcon = 7;
+			
+			// aapt resource value: 8
+			public const int SearchView_iconifiedByDefault = 8;
+			
+			// aapt resource value: 9
+			public const int SearchView_layout = 9;
+			
+			// aapt resource value: 10
+			public const int SearchView_queryBackground = 10;
+			
+			// aapt resource value: 11
+			public const int SearchView_queryHint = 11;
+			
+			// aapt resource value: 12
+			public const int SearchView_searchHintIcon = 12;
+			
+			// aapt resource value: 13
+			public const int SearchView_searchIcon = 13;
+			
+			// aapt resource value: 14
+			public const int SearchView_submitBackground = 14;
+			
+			// aapt resource value: 15
+			public const int SearchView_suggestionRowLayout = 15;
+			
+			// aapt resource value: 16
+			public const int SearchView_voiceIcon = 16;
+			
+			// aapt resource value: { 0x101011F,0x7F03007F,0x7F0300BE }
+			public static int[] SnackbarLayout = new int[] {
+					16843039,
+					2130903167,
+					2130903230};
+			
+			// aapt resource value: 0
+			public const int SnackbarLayout_android_maxWidth = 0;
+			
+			// aapt resource value: 1
+			public const int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int SnackbarLayout_maxActionInlineWidth = 2;
+			
+			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F0300E0 }
+			public static int[] Spinner = new int[] {
+					16842930,
+					16843126,
+					16843131,
+					16843362,
+					2130903264};
+			
+			// aapt resource value: 3
+			public const int Spinner_android_dropDownWidth = 3;
+			
+			// aapt resource value: 0
+			public const int Spinner_android_entries = 0;
+			
+			// aapt resource value: 1
+			public const int Spinner_android_popupBackground = 1;
+			
+			// aapt resource value: 2
+			public const int Spinner_android_prompt = 2;
+			
+			// aapt resource value: 4
+			public const int Spinner_popupTheme = 4;
+			
+			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F0300F8,0x7F0300FF,0x7F03010E,0x7F03010F,0x7F030111,0x7F030130,0x7F030131,0x7F030132,0x7F030146,0x7F030147,0x7F030148 }
+			public static int[] SwitchCompat = new int[] {
+					16843044,
+					16843045,
+					16843074,
+					2130903288,
+					2130903295,
+					2130903310,
+					2130903311,
+					2130903313,
+					2130903344,
+					2130903345,
+					2130903346,
+					2130903366,
+					2130903367,
+					2130903368};
+			
+			// aapt resource value: 1
+			public const int SwitchCompat_android_textOff = 1;
+			
+			// aapt resource value: 0
+			public const int SwitchCompat_android_textOn = 0;
+			
+			// aapt resource value: 2
+			public const int SwitchCompat_android_thumb = 2;
+			
+			// aapt resource value: 3
+			public const int SwitchCompat_showText = 3;
+			
+			// aapt resource value: 4
+			public const int SwitchCompat_splitTrack = 4;
+			
+			// aapt resource value: 5
+			public const int SwitchCompat_switchMinWidth = 5;
+			
+			// aapt resource value: 6
+			public const int SwitchCompat_switchPadding = 6;
+			
+			// aapt resource value: 7
+			public const int SwitchCompat_switchTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public const int SwitchCompat_thumbTextPadding = 8;
+			
+			// aapt resource value: 9
+			public const int SwitchCompat_thumbTint = 9;
+			
+			// aapt resource value: 10
+			public const int SwitchCompat_thumbTintMode = 10;
+			
+			// aapt resource value: 11
+			public const int SwitchCompat_track = 11;
+			
+			// aapt resource value: 12
+			public const int SwitchCompat_trackTint = 12;
+			
+			// aapt resource value: 13
+			public const int SwitchCompat_trackTintMode = 13;
+			
+			// aapt resource value: { 0x1010002,0x10100F2,0x101014F }
+			public static int[] TabItem = new int[] {
+					16842754,
+					16842994,
+					16843087};
+			
+			// aapt resource value: 0
+			public const int TabItem_android_icon = 0;
+			
+			// aapt resource value: 1
+			public const int TabItem_android_layout = 1;
+			
+			// aapt resource value: 2
+			public const int TabItem_android_text = 2;
+			
+			// aapt resource value: { 0x7F030112,0x7F030113,0x7F030114,0x7F030115,0x7F030116,0x7F030117,0x7F030118,0x7F030119,0x7F03011A,0x7F03011B,0x7F03011C,0x7F03011D,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121 }
+			public static int[] TabLayout = new int[] {
+					2130903314,
+					2130903315,
+					2130903316,
+					2130903317,
+					2130903318,
+					2130903319,
+					2130903320,
+					2130903321,
+					2130903322,
+					2130903323,
+					2130903324,
+					2130903325,
+					2130903326,
+					2130903327,
+					2130903328,
+					2130903329};
+			
+			// aapt resource value: 0
+			public const int TabLayout_tabBackground = 0;
+			
+			// aapt resource value: 1
+			public const int TabLayout_tabContentStart = 1;
+			
+			// aapt resource value: 2
+			public const int TabLayout_tabGravity = 2;
+			
+			// aapt resource value: 3
+			public const int TabLayout_tabIndicatorColor = 3;
+			
+			// aapt resource value: 4
+			public const int TabLayout_tabIndicatorHeight = 4;
+			
+			// aapt resource value: 5
+			public const int TabLayout_tabMaxWidth = 5;
+			
+			// aapt resource value: 6
+			public const int TabLayout_tabMinWidth = 6;
+			
+			// aapt resource value: 7
+			public const int TabLayout_tabMode = 7;
+			
+			// aapt resource value: 8
+			public const int TabLayout_tabPadding = 8;
+			
+			// aapt resource value: 9
+			public const int TabLayout_tabPaddingBottom = 9;
+			
+			// aapt resource value: 10
+			public const int TabLayout_tabPaddingEnd = 10;
+			
+			// aapt resource value: 11
+			public const int TabLayout_tabPaddingStart = 11;
+			
+			// aapt resource value: 12
+			public const int TabLayout_tabPaddingTop = 12;
+			
+			// aapt resource value: 13
+			public const int TabLayout_tabSelectedTextColor = 13;
+			
+			// aapt resource value: 14
+			public const int TabLayout_tabTextAppearance = 14;
+			
+			// aapt resource value: 15
+			public const int TabLayout_tabTextColor = 15;
+			
+			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x1010161,0x1010162,0x1010163,0x1010164,0x7F030122 }
+			public static int[] TextAppearance = new int[] {
+					16842901,
+					16842902,
+					16842903,
+					16842904,
+					16842906,
+					16843105,
+					16843106,
+					16843107,
+					16843108,
+					2130903330};
+			
+			// aapt resource value: 5
+			public const int TextAppearance_android_shadowColor = 5;
+			
+			// aapt resource value: 6
+			public const int TextAppearance_android_shadowDx = 6;
+			
+			// aapt resource value: 7
+			public const int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public const int TextAppearance_android_shadowRadius = 8;
+			
+			// aapt resource value: 3
+			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public const int TextAppearance_android_textColorHint = 4;
+			
+			// aapt resource value: 0
+			public const int TextAppearance_android_textSize = 0;
+			
+			// aapt resource value: 2
+			public const int TextAppearance_android_textStyle = 2;
+			
+			// aapt resource value: 1
+			public const int TextAppearance_android_typeface = 1;
+			
+			// aapt resource value: 9
+			public const int TextAppearance_textAllCaps = 9;
+			
+			// aapt resource value: { 0x101009A,0x1010150,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030080,0x7F030081,0x7F030093,0x7F030094,0x7F030095,0x7F0300DA,0x7F0300DB,0x7F0300DC,0x7F0300DD,0x7F0300DE }
+			public static int[] TextInputLayout = new int[] {
+					16842906,
+					16843088,
+					2130903147,
+					2130903148,
+					2130903149,
+					2130903150,
+					2130903168,
+					2130903169,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903258,
+					2130903259,
+					2130903260,
+					2130903261,
+					2130903262};
+			
+			// aapt resource value: 1
+			public const int TextInputLayout_android_hint = 1;
+			
+			// aapt resource value: 0
+			public const int TextInputLayout_android_textColorHint = 0;
+			
+			// aapt resource value: 2
+			public const int TextInputLayout_counterEnabled = 2;
+			
+			// aapt resource value: 3
+			public const int TextInputLayout_counterMaxLength = 3;
+			
+			// aapt resource value: 4
+			public const int TextInputLayout_counterOverflowTextAppearance = 4;
+			
+			// aapt resource value: 5
+			public const int TextInputLayout_counterTextAppearance = 5;
+			
+			// aapt resource value: 6
+			public const int TextInputLayout_errorEnabled = 6;
+			
+			// aapt resource value: 7
+			public const int TextInputLayout_errorTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public const int TextInputLayout_hintAnimationEnabled = 8;
+			
+			// aapt resource value: 9
+			public const int TextInputLayout_hintEnabled = 9;
+			
+			// aapt resource value: 10
+			public const int TextInputLayout_hintTextAppearance = 10;
+			
+			// aapt resource value: 11
+			public const int TextInputLayout_passwordToggleContentDescription = 11;
+			
+			// aapt resource value: 12
+			public const int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 13
+			public const int TextInputLayout_passwordToggleEnabled = 13;
+			
+			// aapt resource value: 14
+			public const int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public const int TextInputLayout_passwordToggleTintMode = 15;
+			
+			// aapt resource value: { 0x10100AF,0x1010140,0x7F03003F,0x7F03004F,0x7F030050,0x7F03005E,0x7F03005F,0x7F030060,0x7F030061,0x7F030062,0x7F030063,0x7F0300BC,0x7F0300BD,0x7F0300BF,0x7F0300CF,0x7F0300D0,0x7F0300E0,0x7F030109,0x7F03010A,0x7F03010B,0x7F030138,0x7F03013A,0x7F03013B,0x7F03013C,0x7F03013D,0x7F03013E,0x7F03013F,0x7F030140,0x7F030141 }
+			public static int[] Toolbar = new int[] {
+					16842927,
+					16843072,
+					2130903103,
+					2130903119,
+					2130903120,
+					2130903134,
+					2130903135,
+					2130903136,
+					2130903137,
+					2130903138,
+					2130903139,
+					2130903228,
+					2130903229,
+					2130903231,
+					2130903247,
+					2130903248,
+					2130903264,
+					2130903305,
+					2130903306,
+					2130903307,
+					2130903352,
+					2130903354,
+					2130903355,
+					2130903356,
+					2130903357,
+					2130903358,
+					2130903359,
+					2130903360,
+					2130903361};
+			
+			// aapt resource value: 0
+			public const int Toolbar_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public const int Toolbar_android_minHeight = 1;
+			
+			// aapt resource value: 2
+			public const int Toolbar_buttonGravity = 2;
+			
+			// aapt resource value: 3
+			public const int Toolbar_collapseContentDescription = 3;
+			
+			// aapt resource value: 4
+			public const int Toolbar_collapseIcon = 4;
+			
+			// aapt resource value: 5
+			public const int Toolbar_contentInsetEnd = 5;
+			
+			// aapt resource value: 6
+			public const int Toolbar_contentInsetEndWithActions = 6;
+			
+			// aapt resource value: 7
+			public const int Toolbar_contentInsetLeft = 7;
+			
+			// aapt resource value: 8
+			public const int Toolbar_contentInsetRight = 8;
+			
+			// aapt resource value: 9
+			public const int Toolbar_contentInsetStart = 9;
+			
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetStartWithNavigation = 10;
+			
+			// aapt resource value: 11
+			public const int Toolbar_logo = 11;
+			
+			// aapt resource value: 12
+			public const int Toolbar_logoDescription = 12;
+			
+			// aapt resource value: 13
+			public const int Toolbar_maxButtonHeight = 13;
+			
+			// aapt resource value: 14
+			public const int Toolbar_navigationContentDescription = 14;
+			
+			// aapt resource value: 15
+			public const int Toolbar_navigationIcon = 15;
+			
+			// aapt resource value: 16
+			public const int Toolbar_popupTheme = 16;
+			
+			// aapt resource value: 17
+			public const int Toolbar_subtitle = 17;
+			
+			// aapt resource value: 18
+			public const int Toolbar_subtitleTextAppearance = 18;
+			
+			// aapt resource value: 19
+			public const int Toolbar_subtitleTextColor = 19;
+			
+			// aapt resource value: 20
+			public const int Toolbar_title = 20;
+			
+			// aapt resource value: 21
+			public const int Toolbar_titleMargin = 21;
+			
+			// aapt resource value: 22
+			public const int Toolbar_titleMarginBottom = 22;
+			
+			// aapt resource value: 23
+			public const int Toolbar_titleMarginEnd = 23;
+			
+			// aapt resource value: 26
+			public const int Toolbar_titleMargins = 26;
+			
+			// aapt resource value: 24
+			public const int Toolbar_titleMarginStart = 24;
+			
+			// aapt resource value: 25
+			public const int Toolbar_titleMarginTop = 25;
+			
+			// aapt resource value: 27
+			public const int Toolbar_titleTextAppearance = 27;
+			
+			// aapt resource value: 28
+			public const int Toolbar_titleTextColor = 28;
+			
+			// aapt resource value: { 0x1010000,0x10100DA,0x7F0300D4,0x7F0300D5,0x7F03012E }
+			public static int[] View = new int[] {
+					16842752,
+					16842970,
+					2130903252,
+					2130903253,
+					2130903342};
+			
+			// aapt resource value: { 0x10100D4,0x7F03002E,0x7F03002F }
+			public static int[] ViewBackgroundHelper = new int[] {
+					16842964,
+					2130903086,
+					2130903087};
+			
+			// aapt resource value: 0
+			public const int ViewBackgroundHelper_android_background = 0;
+			
+			// aapt resource value: 1
+			public const int ViewBackgroundHelper_backgroundTint = 1;
+			
+			// aapt resource value: 2
+			public const int ViewBackgroundHelper_backgroundTintMode = 2;
+			
+			// aapt resource value: { 0x10100D0,0x10100F2,0x10100F3 }
+			public static int[] ViewStubCompat = new int[] {
+					16842960,
+					16842994,
+					16842995};
+			
+			// aapt resource value: 0
+			public const int ViewStubCompat_android_id = 0;
+			
+			// aapt resource value: 2
+			public const int ViewStubCompat_android_inflatedId = 2;
+			
+			// aapt resource value: 1
+			public const int ViewStubCompat_android_layout = 1;
+			
+			// aapt resource value: 1
+			public const int View_android_focusable = 1;
+			
+			// aapt resource value: 0
+			public const int View_android_theme = 0;
+			
+			// aapt resource value: 2
+			public const int View_paddingEnd = 2;
+			
+			// aapt resource value: 3
+			public const int View_paddingStart = 3;
+			
+			// aapt resource value: 4
+			public const int View_theme = 4;
+			
+			static Styleable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Styleable()
 			{
 			}
 		}

--- a/samples/features/Features.Forms/Features.Forms/Views/ActionsView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/ActionsView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.ActionsView"
              Title="actions">
 

--- a/samples/features/Features.Forms/Features.Forms/Views/BindingsView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/BindingsView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.BindingsView"
              Title="bindings">
     <Grid>

--- a/samples/features/Features.Forms/Features.Forms/Views/BubblingView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/BubblingView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.BubblingView">
   <Grid>
     <Grid.RowDefinitions>

--- a/samples/features/Features.Forms/Features.Forms/Views/ConductorView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/ConductorView.xaml
@@ -2,7 +2,7 @@
 <TabbedPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Features.CrossPlatform.Views.ConductorView"
-            xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+            xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
             ItemsSource="{Binding Items}"
             SelectedItem="{Binding ActiveItem, Mode=TwoWay}"
             Title ="conductor">

--- a/samples/features/Features.Forms/Features.Forms/Views/CoroutineView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/CoroutineView.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Features.CrossPlatform.Views.CoroutineView"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              Title="coroutines">
     <StackLayout>
         <Button cm:Message.Attach="Execute" Text="Execute Coroutine"/>

--- a/samples/features/Features.Forms/Features.Forms/Views/EventAggregationView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/EventAggregationView.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Features.CrossPlatform.Views.EventAggregationView"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              Title="event aggregation">
     <Grid>
         <Grid.RowDefinitions>

--- a/samples/features/Features.Forms/Features.Forms/Views/Events/EventDestinationView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/Events/EventDestinationView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.Events.EventDestinationView">
     
     <Grid>

--- a/samples/features/Features.Forms/Features.Forms/Views/Events/EventSourceView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/Events/EventSourceView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.Events.EventSourceView">
     <StackLayout>
         <Label Text="Source" FontSize="24" />

--- a/samples/features/Features.Forms/Features.Forms/Views/ExecuteView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/ExecuteView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.ExecuteView"
              Title="execute">
     <StackLayout>

--- a/samples/features/Features.Forms/Features.Forms/Views/MenuView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/MenuView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.MenuView"
              Title="features">
     <Grid>

--- a/samples/features/Features.Forms/Features.Forms/Views/NavigationSourceView.xaml
+++ b/samples/features/Features.Forms/Features.Forms/Views/NavigationSourceView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Platform.Xamarin.Forms"
+             xmlns:cm="clr-namespace:Caliburn.Micro.Xamarin.Forms;assembly=Caliburn.Micro.Xamarin.Forms"
              x:Class="Features.CrossPlatform.Views.NavigationSourceView"
              Title="navigation">
 	<StackLayout>

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/NavigationPageAdapter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/NavigationPageAdapter.cs
@@ -157,11 +157,6 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewModelAsync<T>(object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAsync();
-
-            if (!canClose)
-                return;
-
             await NavigateToViewModelAsync(typeof(T), parameter, animated);
         }
 
@@ -193,15 +188,10 @@
         /// <returns>The asynchrous task representing the transition</returns>
         public async Task NavigateToViewAsync<T>(object parameter = null, bool animated = true)
         {
-            var canClose = await CanCloseAsync();
-
-            if (!canClose)
-                return;
-
             await NavigateToViewAsync(typeof(T), parameter, animated);
         }
 
-        private Task PushAsync(Element view, object parameter, bool animated)
+        private async Task PushAsync(Element view, object parameter, bool animated)
         {
             var page = view as Page;
 
@@ -214,6 +204,11 @@
                 TryInjectParameters(viewModel, parameter);
 
                 ViewModelBinder.Bind(viewModel, view, null);
+
+                if (viewModel is IActivate activator)
+                {
+                    await activator.ActivateAsync();
+                }
             }
 
             var contentView = view as ContentView;
@@ -221,7 +216,7 @@
                 page = CreateContentPage(contentView, viewModel);
             }
 
-            return navigationPage.PushAsync(page, animated);
+            await navigationPage.PushAsync(page, animated);
         }
 
         /// <summary>


### PR DESCRIPTION
Removed CanClose call from generic NavigateTo versions. Made the features sample work on android.

Fixes #749