### PR TITLE
Add DisplayRootViewForAsync<T> for net 461 and dot net core

### DIFF
--- a/samples/features/Features.NetCore/Bootstrapper.cs
+++ b/samples/features/Features.NetCore/Bootstrapper.cs
@@ -41,9 +41,9 @@ namespace Features.CrossPlatform
                .PerRequest<NavigationTargetViewModel>();
         }
 
-        protected override void OnStartup(object sender, StartupEventArgs e)
+        protected override async void OnStartup(object sender, StartupEventArgs e)
         {
-            DisplayRootViewFor<ShellViewModel>();
+           await DisplayRootViewForAsync<ShellViewModel>();
         }
 
         protected override object GetInstance(Type service, string key)

--- a/samples/features/Features.NetFive/Bootstrapper.cs
+++ b/samples/features/Features.NetFive/Bootstrapper.cs
@@ -41,9 +41,9 @@ namespace Features.CrossPlatform
                .PerRequest<NavigationTargetViewModel>();
         }
 
-        protected override void OnStartup(object sender, StartupEventArgs e)
+        protected override async void OnStartup(object sender, StartupEventArgs e)
         {
-            DisplayRootViewFor<ShellViewModel>();
+            await DisplayRootViewForAsync<ShellViewModel>();
         }
 
         protected override object GetInstance(Type service, string key)

--- a/samples/features/Features.WPF/Bootstrapper.cs
+++ b/samples/features/Features.WPF/Bootstrapper.cs
@@ -41,9 +41,9 @@ namespace Features.CrossPlatform
                .PerRequest<NavigationTargetViewModel>();
         }
 
-        protected override void OnStartup(object sender, StartupEventArgs e)
+        protected override async void OnStartup(object sender, StartupEventArgs e)
         {
-            DisplayRootViewFor<ShellViewModel>();
+           await DisplayRootViewForAsync<ShellViewModel>();
         }
 
         protected override object GetInstance(Type service, string key)

--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
@@ -218,5 +218,15 @@ namespace Caliburn.Micro
         {
             return DisplayRootViewForAsync(typeof(TViewModel), settings);
         }
+
+        /// <summary>
+        /// Locates the view model, locates the associate view, binds them and shows it as the root view.
+        /// </summary>
+        /// <typeparam name="TViewModel">The view model type.</typeparam>
+        /// <param name="settings">The optional window settings.</param>
+        protected Task DisplayRootViewForAsync<TViewModel>(IDictionary<string, object> settings = null)
+        {
+            return DisplayRootViewForAsync(typeof(TViewModel), settings);
+        }
     }
 }

--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/Bootstrapper.cs
@@ -209,15 +209,6 @@ namespace Caliburn.Micro
             await windowManager.ShowWindowAsync(IoC.GetInstance(viewModelType, null), null, settings);
         }
 
-        /// <summary>
-        /// Locates the view model, locates the associate view, binds them and shows it as the root view.
-        /// </summary>
-        /// <typeparam name="TViewModel">The view model type.</typeparam>
-        /// <param name="settings">The optional window settings.</param>
-        protected Task DisplayRootViewFor<TViewModel>(IDictionary<string, object> settings = null)
-        {
-            return DisplayRootViewForAsync(typeof(TViewModel), settings);
-        }
 
         /// <summary>
         /// Locates the view model, locates the associate view, binds them and shows it as the root view.

--- a/src/Caliburn.Micro.Platform/Platforms/net46/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46/Bootstrapper.cs
@@ -218,5 +218,15 @@ namespace Caliburn.Micro
         {
             return DisplayRootViewForAsync(typeof(TViewModel), settings);
         }
+
+        /// <summary>
+        /// Locates the view model, locates the associate view, binds them and shows it as the root view.
+        /// </summary>
+        /// <typeparam name="TViewModel">The view model type.</typeparam>
+        /// <param name="settings">The optional window settings.</param>
+        protected Task DisplayRootViewForAsync<TViewModel>(IDictionary<string, object> settings = null)
+        {
+            return DisplayRootViewForAsync(typeof(TViewModel), settings);
+        }
     }
 }

--- a/src/Caliburn.Micro.Platform/Platforms/net46/Bootstrapper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46/Bootstrapper.cs
@@ -209,15 +209,6 @@ namespace Caliburn.Micro
             await windowManager.ShowWindowAsync(IoC.GetInstance(viewModelType, null), null, settings);
         }
 
-        /// <summary>
-        /// Locates the view model, locates the associate view, binds them and shows it as the root view.
-        /// </summary>
-        /// <typeparam name="TViewModel">The view model type.</typeparam>
-        /// <param name="settings">The optional window settings.</param>
-        protected Task DisplayRootViewFor<TViewModel>(IDictionary<string, object> settings = null)
-        {
-            return DisplayRootViewForAsync(typeof(TViewModel), settings);
-        }
 
         /// <summary>
         /// Locates the view model, locates the associate view, binds them and shows it as the root view.


### PR DESCRIPTION
Adds DisplayRootViewForAsync<T> to .net framework and .net core wpf projects.  This is related to issue #760 