### PR TITLE
Added async eventhandler to IActivate

### DIFF
--- a/src/Caliburn.Micro.Core.Tests/ScreenExtentionTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/ScreenExtentionTests.cs
@@ -37,6 +37,10 @@ namespace Caliburn.Micro.Core.Tests
 
             await ScreenExtensions.TryActivateAsync(root).ConfigureAwait(false);
 
+            Assert.True(child1.WasActivated, "child 1 should be active");
+            Assert.True(child2.WasActivated, "child 2 should be active");
+            Assert.True(child3.WasActivated, "child 3 should be active");
+
             await ScreenExtensions.TryDeactivateAsync(root, true).ConfigureAwait(false);
 
             Assert.True(child1.IsClosed, "child 1 should be closed");
@@ -55,7 +59,8 @@ namespace Caliburn.Micro.Core.Tests
             };
             var child2 = new StateScreen(TimeSpan.FromSeconds(3))
             {
-                DisplayName = "screen2"
+                DisplayName = "screen2",
+                IsClosable = false,
             };
 
             var child3 = new StateScreen()
@@ -68,6 +73,10 @@ namespace Caliburn.Micro.Core.Tests
             root.Items.Add(child3);
 
             await ScreenExtensions.TryActivateAsync(root).ConfigureAwait(false);
+
+            Assert.True(child1.WasActivated, "child 1 should be active");
+            Assert.True(child2.WasActivated, "child 2 should be active");
+            Assert.True(child3.WasActivated, "child 3 should be active");
 
             await ScreenExtensions.TryDeactivateAsync(root, true).ConfigureAwait(false);
 
@@ -87,12 +96,26 @@ namespace Caliburn.Micro.Core.Tests
                 this.deactivationDelay = deactivationDelay;
             }
 
+            public bool WasActivated { get; private set; }
             public bool IsClosed { get; private set; }
             public bool IsClosable { get; set; }
 
             public override Task<bool> CanCloseAsync(CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(IsClosable);
+            }
+
+            protected override async Task OnActivateAsync(CancellationToken cancellationToken)
+            {
+                if (deactivationDelay.HasValue)
+                {
+                    await Task.Delay(deactivationDelay.Value, cancellationToken).ConfigureAwait(false);
+                }
+
+                await base.OnActivateAsync(cancellationToken);
+
+                WasActivated = true;
+                IsClosable = false;
             }
 
             protected override async Task OnDeactivateAsync(bool close, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Caliburn.Micro.Core/IActivate.cs
+++ b/src/Caliburn.Micro.Core/IActivate.cs
@@ -24,6 +24,6 @@ namespace Caliburn.Micro
         /// <summary>
         /// Raised after activation occurs.
         /// </summary>
-        event EventHandler<ActivationEventArgs> Activated;
+        event AsyncEventHandler<ActivationEventArgs> Activated;
     }
 }

--- a/src/Caliburn.Micro.Core/Screen.cs
+++ b/src/Caliburn.Micro.Core/Screen.cs
@@ -81,7 +81,7 @@ namespace Caliburn.Micro
         /// <summary>
         /// Raised after activation occurs.
         /// </summary>
-        public virtual event EventHandler<ActivationEventArgs> Activated = delegate { };
+        public virtual event AsyncEventHandler<ActivationEventArgs> Activated = delegate { return Task.FromResult(true); };
 
         /// <summary>
         /// Raised before deactivation.
@@ -110,10 +110,10 @@ namespace Caliburn.Micro
             await OnActivateAsync(cancellationToken);
             IsActive = true;
 
-            Activated?.Invoke(this, new ActivationEventArgs
+            await (Activated?.InvokeAllAsync(this, new ActivationEventArgs
             {
                 WasInitialized = initialized
-            });
+            }) ?? Task.FromResult(true));
         }
 
         async Task IDeactivate.DeactivateAsync(bool close, CancellationToken cancellationToken)

--- a/src/Caliburn.Micro.Core/ScreenExtensions.cs
+++ b/src/Caliburn.Micro.Core/ScreenExtensions.cs
@@ -107,13 +107,13 @@ namespace Caliburn.Micro
         {
             var childReference = new WeakReference(child);
 
-            void OnParentActivated(object s, ActivationEventArgs e)
+            async Task OnParentActivated(object s, ActivationEventArgs e)
             {
                 var activatable = (IActivate)childReference.Target;
                 if (activatable == null)
                     ((IActivate)s).Activated -= OnParentActivated;
                 else
-                    activatable.ActivateAsync(CancellationToken.None);
+                    await activatable.ActivateAsync(CancellationToken.None);
             }
 
             parent.Activated += OnParentActivated;
@@ -127,16 +127,17 @@ namespace Caliburn.Micro
         public static void DeactivateWith(this IDeactivate child, IDeactivate parent)
         {
             var childReference = new WeakReference(child);
-            AsyncEventHandler<DeactivationEventArgs> handler = null;
-            handler = async (s, e) =>
+
+            async Task OnParentDeactivated(object s, DeactivationEventArgs e)
             {
                 var deactivatable = (IDeactivate)childReference.Target;
                 if (deactivatable == null)
-                    ((IDeactivate)s).Deactivated -= handler;
+                    ((IDeactivate)s).Deactivated -= OnParentDeactivated;
                 else
                     await deactivatable.DeactivateAsync(e.WasClosed, CancellationToken.None);
-            };
-            parent.Deactivated += handler;
+            }
+
+            parent.Deactivated += OnParentDeactivated;
         }
 
         ///<summary>

--- a/src/Caliburn.Micro.Core/ViewAware.cs
+++ b/src/Caliburn.Micro.Core/ViewAware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Caliburn.Micro
 {
@@ -59,7 +60,7 @@ namespace Caliburn.Micro
         private static void AttachViewReadyOnActivated(IActivate activatable, object nonGeneratedView)
         {
             var viewReference = new WeakReference(nonGeneratedView);
-            EventHandler<ActivationEventArgs> handler = null;
+            AsyncEventHandler<ActivationEventArgs> handler = null;
             handler = (s, e) =>
             {
                 ((IActivate)s).Activated -= handler;
@@ -68,6 +69,8 @@ namespace Caliburn.Micro
                 {
                     PlatformProvider.Current.ExecuteOnLayoutUpdated(view, ((ViewAware)s).OnViewReady);
                 }
+
+                return Task.CompletedTask;
             };
             activatable.Activated += handler;
         }


### PR DESCRIPTION
This fixes #762, and makes it so that `ConductWith` has the same behavior for `Activate` and `Deactivate`. 