### PR TITLE
remove nuget packages that are not needed for .net 5 and 6

### DIFF
--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -48,13 +48,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows'">
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.37" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     <Compile Include="Platforms\net46-netcore\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.37" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2"  />
     <Compile Include="Platforms\net46-netcore\**\*.cs" />
   </ItemGroup>
   


### PR DESCRIPTION
Remove Nuget package Microsoft.Windows.Compatibility which is not needed for .net 5 and .net 6 wpf apps.

Closes Bug #786 