### PR TITLE
Do not call InitializeComponent for Avalonia.

### DIFF
--- a/src/Caliburn.Micro.Platform/ViewLocator.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocator.cs
@@ -515,13 +515,6 @@ namespace Caliburn.Micro
                 .SingleOrDefault(m => m.GetParameters().Length == 0);
 
             method?.Invoke(element, null);
-#elif AVALONIA
-            var method = element.GetType()
-                .GetMethod("InitializeComponent", BindingFlags.Public | BindingFlags.Instance);
-
-            var arguments = Enumerable.Repeat(Type.Missing, method.GetParameters().Length).ToArray();
-
-            method?.Invoke(element, arguments);
 #else
             var method = element.GetType()
                 .GetMethod("InitializeComponent", BindingFlags.Public | BindingFlags.Instance);


### PR DESCRIPTION
My fix from before should be removed. According to danwalmsley we don't need to call it, the default constructor of a control will do it for us. And if a user decides to use a non-default constructor then it is his responsibility to do it at the right moment. He added the `|| AVALONIA` on line 510 for that reason.