### PR TITLE
Avalonia -> dont call InitialiseComponent, apps crash otherwise

### DIFF
--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -8,7 +8,7 @@
     <AssemblyOriginatorKeyFile>.\..\Caliburn.Micro.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>10</LangVersion>
-    <AvaloniaVersion>11.0.999-cibuild0032174-beta</AvaloniaVersion>
+    <AvaloniaVersion>11.0.999-cibuild0032488-beta</AvaloniaVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,7 +22,6 @@
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.0-preview6" />
     <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.0.0-preview6" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />
     <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" />
   </ItemGroup>

--- a/src/Caliburn.Micro.Platform/ViewLocator.cs
+++ b/src/Caliburn.Micro.Platform/ViewLocator.cs
@@ -510,7 +510,7 @@ namespace Caliburn.Micro
         /// <param name = "element">The element to initialize</param>
         public static void InitializeComponent(object element)
         {
-#if XFORMS
+#if XFORMS || AVALONIA
             return;
 #elif WINDOWS_UWP
             var method = element.GetType().GetTypeInfo()
@@ -518,25 +518,6 @@ namespace Caliburn.Micro
                 .SingleOrDefault(m => m.GetParameters().Length == 0);
 
             method?.Invoke(element, null);
-#elif AVALONIA
-            var method = element.GetType()
-                .GetMethod("InitializeComponent", BindingFlags.Public | BindingFlags.Instance);
-            var methodParameters = method.GetParameters();
-            var myParams = new List<object>();
-            Log.Info($"Method parameters {method.GetParameters().Count()}");
-            foreach (var p in method.GetParameters())
-            {
-                Log.Info($"Parameter name {p.Name} - {p.ParameterType}");
-                if (p.Name == "loadXaml")
-                {
-                    myParams.Add(true);
-                }
-                else if (p.Name == "attachDevTools")
-                {
-                    myParams.Add(System.Diagnostics.Debugger.IsAttached);
-                }
-            }
-            method?.Invoke(element, myParams.ToArray());
 #else
             var method = element.GetType()
                 .GetMethod("InitializeComponent", BindingFlags.Public | BindingFlags.Instance);


### PR DESCRIPTION
Recent changes meant that initialisecomponent was getting called twice, once by the call generated by avalonia from the view ctor, and again via reflection, causing apps to crash.