### PR TITLE
Add `readonly` modifier to fields

### DIFF
--- a/src/Caliburn.Micro.Core/SimpleContainer.cs
+++ b/src/Caliburn.Micro.Core/SimpleContainer.cs
@@ -15,7 +15,7 @@ namespace Caliburn.Micro
         private static readonly Type enumerableType = typeof(IEnumerable);
         private static readonly TypeInfo enumerableTypeInfo = enumerableType.GetTypeInfo();
         private static readonly TypeInfo delegateTypeInfo = delegateType.GetTypeInfo();
-        private Type simpleContainerType = typeof(SimpleContainer);
+        private readonly Type simpleContainerType = typeof(SimpleContainer);
         private readonly List<ContainerEntry> entries;
 
         /// <summary>

--- a/src/Caliburn.Micro.Platform/Bind.cs
+++ b/src/Caliburn.Micro.Platform/Bind.cs
@@ -53,7 +53,7 @@ namespace Caliburn.Micro
                 null, 
                 ModelWithoutContextChanged);
 
-        internal static DependencyProperty NoContextProperty =
+        internal static readonly DependencyProperty NoContextProperty =
             DependencyPropertyHelper.RegisterAttached(
                 "NoContext",
                 typeof(bool),

--- a/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
@@ -16,7 +16,7 @@
     /// </summary>
     public class MauiPlatformProvider : IPlatformProvider 
     {
-        private CoreDispatcher dispatcher;
+        private readonly CoreDispatcher dispatcher;
 
 
         /// <summary>

--- a/src/Caliburn.Micro.Platform/Platforms/uap/FrameAdapter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/FrameAdapter.cs
@@ -17,7 +17,7 @@ namespace Caliburn.Micro
     public class FrameAdapter : INavigationService, IDisposable
     {
 #if WINDOWS_UWP
-        private SystemNavigationManager navigationManager;
+        private readonly SystemNavigationManager navigationManager;
 #endif 
         private static readonly ILog Log = LogManager.GetLog(typeof(FrameAdapter));
         private const string FrameStateKey = "FrameState";

--- a/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
@@ -86,9 +86,9 @@
             return xamlMember;
         }
 
-        private Dictionary<string, IXamlType> _xamlTypes = new Dictionary<string, IXamlType>();
-        private Dictionary<string, IXamlMember> _xamlMembers = new Dictionary<string, IXamlMember>();
-        private Dictionary<Type, string> _xamlTypeToStandardName = new Dictionary<Type, string>();
+        private readonly Dictionary<string, IXamlType> _xamlTypes = new Dictionary<string, IXamlType>();
+        private readonly Dictionary<string, IXamlMember> _xamlMembers = new Dictionary<string, IXamlMember>();
+        private readonly Dictionary<Type, string> _xamlTypeToStandardName = new Dictionary<Type, string>();
 
         private void AddToMapOfTypeToStandardName(Type t, String str) {
             if (!_xamlTypeToStandardName.ContainsKey(t)) {
@@ -152,8 +152,8 @@
 
 
     internal class XamlSystemBaseType : IXamlType {
-        private string _fullName;
-        private Type _underlyingType;
+        private readonly string _fullName;
+        private readonly Type _underlyingType;
 
         public XamlSystemBaseType(string fullName, Type underlyingType) {
             _fullName = fullName;

--- a/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
@@ -17,9 +17,9 @@
     /// </summary>
     public class XamlPlatformProvider : IPlatformProvider {
 #if WINDOWS_UWP
-        private CoreDispatcher dispatcher;
+        private readonly CoreDispatcher dispatcher;
 #else
-        private Dispatcher dispatcher;
+        private readonly Dispatcher dispatcher;
 #endif
 
         /// <summary>


### PR DESCRIPTION
Made several fields `readonly` based on Code QL suggestions (Caliburn-Micro#875). This ensures they are only assigned during declaration or inside constructors.

Affected files:
- src/Caliburn.Micro.Core/SimpleContainer.cs
- src/Caliburn.Micro.Platform/Bind.cs
- src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
- src/Caliburn.Micro.Platform/Platforms/uap/FrameAdapter.cs
- src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
- src/Caliburn.Micro.Platform/XamlPlatformProvider.cs