### PR TITLE
This change was made to enhance code cleanliness and efficiency in tutorial app

### DIFF
--- a/samples/tutorals/WPF/Wpf.Tutorial/Caliburn.Micro.Tutorial.Wpf/Bootstrapper.cs
+++ b/samples/tutorals/WPF/Wpf.Tutorial/Caliburn.Micro.Tutorial.Wpf/Bootstrapper.cs
@@ -43,7 +43,7 @@ namespace Caliburn.Micro.Tutorial.Wpf
 
     protected override async void OnStartup(object sender, StartupEventArgs e)
       {
-      var c= IoC.Get<SimpleContainer>();
+      IoC.Get<SimpleContainer>();
       await DisplayRootViewForAsync(typeof(ShellViewModel));
       }
 


### PR DESCRIPTION
List of Changes:
1. The code line initializing a variable "c" with the instance of "SimpleContainer" has been altered. The updated code no longer assigns the instance to the variable "c", but simply gets the instance of "SimpleContainer" without storing it in any variable. This change suggests that the variable "c" was not being used elsewhere in the code, hence it was removed to improve code cleanliness and efficiency. 