### PR TITLE
update sample app to use .net 8

### DIFF
--- a/samples/tutorals/WPF/Wpf.Tutorial/Caliburn.Micro.Tutorial.Wpf/Caliburn.Micro.Tutorial.Wpf.csproj
+++ b/samples/tutorals/WPF/Wpf.Tutorial/Caliburn.Micro.Tutorial.Wpf/Caliburn.Micro.Tutorial.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the target framework for the WPF tutorial project to ensure compatibility with the latest .NET version.

Framework Update:

* [`samples/tutorals/WPF/Wpf.Tutorial/Caliburn.Micro.Tutorial.Wpf/Caliburn.Micro.Tutorial.Wpf.csproj`](diffhunk://#diff-f33a5c041ffb95bdb7f5ce1b3d14f8483f8751040f5f05b0328392a2724b8cc4L5-R5): Updated the target framework from `netcoreapp3.1` to `net8.0-windows`.

closes #912 