### PR TITLE
Refactor ActionMessage class for readability and remove if statement that is not needed for UWP

### DIFF
--- a/src/Caliburn.Micro.Platform/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/ActionMessage.cs
@@ -35,7 +35,8 @@
     [DefaultTrigger(typeof(ButtonBase), typeof(EventTrigger), "Click")]
     [TypeConstraint(typeof(FrameworkElement))]
 #endif
-    public class ActionMessage : TriggerAction<FrameworkElement>, IHaveParameters {
+    public class ActionMessage : TriggerAction<FrameworkElement>, IHaveParameters
+    {
         static readonly ILog Log = LogManager.GetLog(typeof(ActionMessage));
         ActionExecutionContext context;
 
@@ -83,7 +84,8 @@
         /// <summary>
         /// Creates an instance of <see cref="ActionMessage"/>.
         /// </summary>
-        public ActionMessage() {
+        public ActionMessage()
+        {
             SetValue(ParametersProperty, new AttachedCollection<Parameter>());
         }
 
@@ -94,7 +96,8 @@
 #if !WINDOWS_UWP
         [Category("Common Properties")]
 #endif
-        public string MethodName {
+        public string MethodName
+        {
             get { return (string)GetValue(MethodNameProperty); }
             set { SetValue(MethodNameProperty, value); }
         }
@@ -106,7 +109,8 @@
 #if !WINDOWS_UWP
         [Category("Common Properties")]
 #endif
-        public AttachedCollection<Parameter> Parameters {
+        public AttachedCollection<Parameter> Parameters
+        {
             get { return (AttachedCollection<Parameter>)GetValue(ParametersProperty); }
         }
 
@@ -125,13 +129,8 @@
                 Parameters.OfType<Parameter>().Apply(x => x.MakeAwareOf(this));
 
                 
-                if (View.ExecuteOnLoad(AssociatedObject, ElementLoaded)) {
-                    // Not yet sure if this will be needed
-                    //var trigger = Interaction.GetTriggers(AssociatedObject)
-                    //    .FirstOrDefault(t => t.Actions.Contains(this)) as EventTrigger;
-                    //if (trigger != null && trigger.EventName == "Loaded")
-                    //    Invoke(new RoutedEventArgs());
-                }
+                View.ExecuteOnLoad(AssociatedObject, ElementLoaded);
+
 
                 View.ExecuteOnUnload(AssociatedObject, ElementUnloaded);
             }
@@ -144,12 +143,15 @@
             OnDetaching();
         }
 #else
-        protected override void OnAttached() {
-            if (!View.InDesignMode) {
+        protected override void OnAttached()
+        {
+            if (!View.InDesignMode)
+            {
                 Parameters.Attach(AssociatedObject);
                 Parameters.Apply(x => x.MakeAwareOf(this));
 
-                if (View.ExecuteOnLoad(AssociatedObject, ElementLoaded)) {
+                if (View.ExecuteOnLoad(AssociatedObject, ElementLoaded))
+                {
                     var trigger = Interaction.GetTriggers(AssociatedObject)
                         .FirstOrDefault(t => t.Actions.Contains(this)) as EventTrigger;
                     if (trigger != null && trigger.EventName == "Loaded")
@@ -161,15 +163,18 @@
         }
 #endif
 
-        static void HandlerPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        static void HandlerPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
             ((ActionMessage)d).UpdateContext();
         }
 
         /// <summary>
         /// Called when the action is being detached from its AssociatedObject, but before it has actually occurred.
         /// </summary>
-        protected override void OnDetaching() {
-            if (!View.InDesignMode) {
+        protected override void OnDetaching()
+        {
+            if (!View.InDesignMode)
+            {
                 Detaching(this, EventArgs.Empty);
                 AssociatedObject.Loaded -= ElementLoaded;
                 Parameters.Detach();
@@ -178,24 +183,29 @@
             base.OnDetaching();
         }
 
-        void ElementLoaded(object sender, RoutedEventArgs e) {
+        void ElementLoaded(object sender, RoutedEventArgs e)
+        {
             UpdateContext();
 
             DependencyObject currentElement;
-            if (context.View == null) {
+            if (context.View == null)
+            {
                 currentElement = AssociatedObject;
-                while (currentElement != null) {
+                while (currentElement != null)
+                {
                     if (Action.HasTargetSet(currentElement))
                         break;
 
                     currentElement = BindingScope.GetVisualParent(currentElement);
                 }
             }
-            else currentElement = context.View;
+            else
+                currentElement = context.View;
 
 #if NET || CAL_NETCORE
-            var binding = new Binding {
-                Path = new PropertyPath(Message.HandlerProperty), 
+            var binding = new Binding
+            {
+                Path = new PropertyPath(Message.HandlerProperty),
                 Source = currentElement
             };
 #elif WINDOWS_UWP
@@ -211,11 +221,13 @@
             BindingOperations.SetBinding(this, HandlerProperty, binding);
         }
 
-        void UpdateContext() {
+        void UpdateContext()
+        {
             if (context != null)
                 context.Dispose();
 
-            context = new ActionExecutionContext {
+            context = new ActionExecutionContext
+            {
                 Message = this,
                 Source = AssociatedObject
             };
@@ -228,16 +240,20 @@
         /// Invokes the action.
         /// </summary>
         /// <param name="eventArgs">The parameter to the action. If the action does not require a parameter, the parameter may be set to a null reference.</param>
-        protected override void Invoke(object eventArgs) {
+        protected override void Invoke(object eventArgs)
+        {
             Log.Info("Invoking {0}.", this);
 
-            if (context == null) {
+            if (context == null)
+            {
                 UpdateContext();
             }
 
-            if (context.Target == null || context.View == null) {
+            if (context.Target == null || context.View == null)
+            {
                 PrepareContext(context);
-                if (context.Target == null) {
+                if (context.Target == null)
+                {
                     var ex = new Exception(string.Format("No target found for method {0}.", context.Message.MethodName));
                     Log.Error(ex);
 
@@ -246,12 +262,14 @@
                     throw ex;
                 }
 
-                if (!UpdateAvailabilityCore()) {
+                if (!UpdateAvailabilityCore())
+                {
                     return;
                 }
             }
 
-            if (context.Method == null) {
+            if (context.Method == null)
+            {
                 var ex = new Exception(string.Format("Method {0} not found on target of type {1}.", context.Message.MethodName, context.Target.GetType()));
                 Log.Error(ex);
 
@@ -262,7 +280,8 @@
 
             context.EventArgs = eventArgs;
 
-            if (EnforceGuardsDuringInvocation && context.CanExecute != null && !context.CanExecute()) {
+            if (EnforceGuardsDuringInvocation && context.CanExecute != null && !context.CanExecute())
+            {
                 return;
             }
 
@@ -273,7 +292,8 @@
         /// <summary>
         /// Forces an update of the UI's Enabled/Disabled state based on the the preconditions associated with the method.
         /// </summary>
-        public virtual void UpdateAvailability() {
+        public virtual void UpdateAvailability()
+        {
             if (context == null)
                 return;
 
@@ -283,7 +303,8 @@
             UpdateAvailabilityCore();
         }
 
-        bool UpdateAvailabilityCore() {
+        bool UpdateAvailabilityCore()
+        {
             Log.Info("{0} availability update.", this);
             return ApplyAvailabilityEffect(context);
         }
@@ -294,34 +315,40 @@
         /// <returns>
         /// A <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
         /// </returns>
-        public override string ToString() {
+        public override string ToString()
+        {
             return "Action: " + MethodName;
         }
 
         /// <summary>
         /// Invokes the action using the specified <see cref="ActionExecutionContext"/>
         /// </summary>
-        public static Action<ActionExecutionContext> InvokeAction = context => {
+        public static Action<ActionExecutionContext> InvokeAction = context =>
+        {
             var values = MessageBinder.DetermineParameters(context, context.Method.GetParameters());
             var returnValue = context.Method.Invoke(context.Target, values);
 
             var task = returnValue as System.Threading.Tasks.Task;
-            if (task != null) {
+            if (task != null)
+            {
                 returnValue = task.AsResult();
             }
-            
+
             var result = returnValue as IResult;
-            if (result != null) {
+            if (result != null)
+            {
                 returnValue = new[] { result };
             }
 
             var enumerable = returnValue as IEnumerable<IResult>;
-            if (enumerable != null) {
+            if (enumerable != null)
+            {
                 returnValue = enumerable.GetEnumerator();
             }
 
             var enumerator = returnValue as IEnumerator<IResult>;
-            if (enumerator != null) {
+            if (enumerator != null)
+            {
                 Coroutine.BeginExecute(enumerator,
                     new CoroutineExecutionContext
                     {
@@ -336,14 +363,16 @@
         /// Applies an availability effect, such as IsEnabled, to an element.
         /// </summary>
         /// <remarks>Returns a value indicating whether or not the action is available.</remarks>
-        public static Func<ActionExecutionContext, bool> ApplyAvailabilityEffect = context => {
+        public static Func<ActionExecutionContext, bool> ApplyAvailabilityEffect = context =>
+        {
 
 #if WINDOWS_UWP
             var source = context.Source as Control;
 #else
             var source = context.Source;
 #endif
-            if (source == null) {
+            if (source == null)
+            {
                 return true;
             }
 
@@ -352,7 +381,8 @@
 #else
             var hasBinding = ConventionManager.HasBinding(source, UIElement.IsEnabledProperty);
 #endif
-            if (!hasBinding && context.CanExecute != null) {
+            if (!hasBinding && context.CanExecute != null)
+            {
                 source.IsEnabled = context.CanExecute();
             }
 
@@ -363,7 +393,8 @@
         /// Finds the method on the target matching the specified message.
         /// </summary>
         /// <returns>The matching method, if available.</returns>
-        public static Func<ActionMessage, object, MethodInfo> GetTargetMethod = (message, target) => {
+        public static Func<ActionMessage, object, MethodInfo> GetTargetMethod = (message, target) =>
+        {
 #if WINDOWS_UWP
             return (from method in target.GetType().GetRuntimeMethods()
                     where method.Name == message.MethodName
@@ -382,23 +413,29 @@
         /// <summary>
         /// Sets the target, method and view on the context. Uses a bubbling strategy by default.
         /// </summary>
-        public static Action<ActionExecutionContext> SetMethodBinding = context => {
+        public static Action<ActionExecutionContext> SetMethodBinding = context =>
+        {
             var source = context.Source;
 
             DependencyObject currentElement = source;
-            while (currentElement != null) {
-                if (Action.HasTargetSet(currentElement)) {
+            while (currentElement != null)
+            {
+                if (Action.HasTargetSet(currentElement))
+                {
                     var target = Message.GetHandler(currentElement);
-                    if (target != null) {
+                    if (target != null)
+                    {
                         var method = GetTargetMethod(context.Message, target);
-                        if (method != null) {
+                        if (method != null)
+                        {
                             context.Method = method;
                             context.Target = target;
                             context.View = currentElement;
                             return;
                         }
                     }
-                    else {
+                    else
+                    {
                         context.View = currentElement;
                         return;
                     }
@@ -407,11 +444,13 @@
                 currentElement = BindingScope.GetVisualParent(currentElement);
             }
 
-            if (source != null && source.DataContext != null) {
+            if (source != null && source.DataContext != null)
+            {
                 var target = source.DataContext;
                 var method = GetTargetMethod(context.Message, target);
 
-                if (method != null) {
+                if (method != null)
+                {
                     context.Target = target;
                     context.Method = method;
                     context.View = source;
@@ -422,7 +461,8 @@
         /// <summary>
         /// Prepares the action execution context for use.
         /// </summary>
-        public static Action<ActionExecutionContext> PrepareContext = context => {
+        public static Action<ActionExecutionContext> PrepareContext = context =>
+        {
             SetMethodBinding(context);
             if (context.Target == null || context.Method == null)
             {
@@ -444,17 +484,20 @@
                 {
                     matchingGuardName = possibleGuardName;
                     guard = GetMethodInfo(targetType, "get_" + matchingGuardName);
-                    if (guard != null) break;
+                    if (guard != null)
+                        break;
                 }
 
                 if (guard == null)
                     return;
 
                 PropertyChangedEventHandler handler = null;
-                handler = (s, e) => {
+                handler = (s, e) =>
+                {
                     if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == matchingGuardName)
                     {
-                        Caliburn.Micro.Execute.OnUIThread(() => {
+                        Caliburn.Micro.Execute.OnUIThread(() =>
+                        {
                             var message = context.Message;
                             if (message == null)
                             {
@@ -467,8 +510,10 @@
                 };
 
                 inpc.PropertyChanged += handler;
-                context.Disposing += delegate { inpc.PropertyChanged -= handler; };
-                context.Message.Detaching += delegate { inpc.PropertyChanged -= handler; };
+                context.Disposing += delegate
+                { inpc.PropertyChanged -= handler; };
+                context.Message.Detaching += delegate
+                { inpc.PropertyChanged -= handler; };
             }
 
             context.CanExecute = () => (bool)guard.Invoke(
@@ -486,23 +531,30 @@
         /// <param name="context">The execution context</param>
         /// <param name="possibleGuardNames">Method names to look for.</param>
         ///<returns>A MethodInfo, if found; null otherwise</returns>
-        static MethodInfo TryFindGuardMethod(ActionExecutionContext context, IEnumerable<string> possibleGuardNames) {
+        static MethodInfo TryFindGuardMethod(ActionExecutionContext context, IEnumerable<string> possibleGuardNames)
+        {
             var targetType = context.Target.GetType();
             MethodInfo guard = null;
             foreach (string possibleGuardName in possibleGuardNames)
             {
                 guard = GetMethodInfo(targetType, possibleGuardName);
-                if (guard != null) break;
+                if (guard != null)
+                    break;
             }
 
-            if (guard == null) return null;
-            if (guard.ContainsGenericParameters) return null;
-            if (!typeof(bool).Equals(guard.ReturnType)) return null;
+            if (guard == null)
+                return null;
+            if (guard.ContainsGenericParameters)
+                return null;
+            if (!typeof(bool).Equals(guard.ReturnType))
+                return null;
 
             var guardPars = guard.GetParameters();
             var actionPars = context.Method.GetParameters();
-            if (guardPars.Length == 0) return guard;
-            if (guardPars.Length != actionPars.Length) return null;
+            if (guardPars.Length == 0)
+                return guard;
+            if (guardPars.Length != actionPars.Length)
+                return null;
 
             var comparisons = guardPars.Zip(
                 context.Method.GetParameters(),
@@ -520,7 +572,8 @@
         /// <summary>
         /// Returns the list of possible names of guard methods / properties for the given method.
         /// </summary>
-        public static Func<MethodInfo, IEnumerable<string>> BuildPossibleGuardNames = method => {
+        public static Func<MethodInfo, IEnumerable<string>> BuildPossibleGuardNames = method =>
+        {
 
             var guardNames = new List<string>();
 
@@ -532,7 +585,8 @@
 
             const string AsyncMethodSuffix = "Async";
 
-            if (methodName.EndsWith(AsyncMethodSuffix, StringComparison.OrdinalIgnoreCase)) {
+            if (methodName.EndsWith(AsyncMethodSuffix, StringComparison.OrdinalIgnoreCase))
+            {
                 guardNames.Add(GuardPrefix + methodName.Substring(0, methodName.Length - AsyncMethodSuffix.Length));
             }
 


### PR DESCRIPTION
Refactored ActionMessage class to improve readability and maintainability:
- Reformatted constructor, properties, methods, and delegates to include braces `{}` on new lines.
- Removed unnecessary comments.
- Removed unnecessary if statement


Closes #918 