### PR TITLE
Make regex in Parser case-insensitive with a timeout

### DIFF
--- a/src/Caliburn.Micro.Platform/Parser.cs
+++ b/src/Caliburn.Micro.Platform/Parser.cs
@@ -47,7 +47,7 @@ namespace Caliburn.Micro
     /// </summary>
     public static class Parser
     {
-        static readonly Regex LongFormatRegularExpression = new Regex(@"^[\s]*\[[^\]]*\][\s]*=[\s]*\[[^\]]*\][\s]*$", RegexOptions.Compiled);
+        static readonly Regex LongFormatRegularExpression = new Regex(@"^[\s]*\[[^\]]*\][\s]*=[\s]*\[[^\]]*\][\s]*$", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromSeconds(10));
         static readonly ILog Log = LogManager.GetLog(typeof(Parser));
 
         /// <summary>


### PR DESCRIPTION
Updated LongFormatRegularExpression in the Parser class to be case-insensitive by adding RegexOptions.IgnoreCase. Also set a timeout of 10 seconds using TimeSpan.FromSeconds(10) to prevent potential performance issues from long-running regex operations.