### PR TITLE
Add .net 9 to platform

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,8 @@ on:
     branches: [master]
   schedule:
     - cron: '26 22 * * 0'
-
+env:
+  caliburn_sln : "src\\caliburn.micro.sln"
 jobs:
   analyse:
     name: Analyse
@@ -65,10 +66,10 @@ jobs:
       run: dotnet workload list
 
     - name: Restore nuget packages
-      run:  msbuild src\caliburn.micro.sln -t:restore
+      run:  msbuild ${{env.caliburn_sln}}  -t:restore
 
     - name: Build app for release
-      run: msbuild src\caliburn.micro.sln /t:Build 
+      run: msbuild ${{env.caliburn_sln}}  /t:Build 
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
       
     - name: Setup Java SDK
       uses: actions/setup-java@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        global-json-file: src/global.json
       
     - name: Setup Java SDK
       uses: actions/setup-java@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,3 @@
-
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
@@ -31,7 +30,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 8.0.x
     - name: Setup Java SDK
       uses: actions/setup-java@v4
       with:
@@ -79,4 +78,4 @@ jobs:
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
-      if: github.event_name != 'pull_request'
+      #if: github.event_name != 'pull_request'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,7 +59,7 @@ jobs:
       run: msbuild ${{env.caliburn_sln}} /t:Build /p:Configuration=${{env.build_configuration}}
 
     - name: Run Unit Tests
-      run: dotnet test src/caliburn.micro.sln  --configuration release -p:CollectCoverage=true -p:CoverletOutputFormat=json --no-build --verbosity normal /p:MergeWith=..\Caliburn.Micro.Core.Tests\coverage.json /m:1   
+      run: dotnet test ${{env.caliburn_sln}}  --configuration ${{env.build_configuration}} -p:CollectCoverage=true -p:CoverletOutputFormat=json --no-build --verbosity normal    
   
     - name: Restore nuget packages for tutorial
       run:  msbuild ${{env.caliburn_tutorial}} -t:restore 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        global-json-file: src/global.json
     - name: Setup Java SDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,3 +1,4 @@
+
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
@@ -15,6 +16,7 @@ env:
   caliburn_features: "samples\\features\\features.sln"
   package_feed: "https://nuget.pkg.github.com/caliburn-micro/index.json"
   nuget_folder: "\\packages"
+  nuget_upload: 'packages\*.nupkg'
   build_configuration: "Release"
   
 jobs:
@@ -29,7 +31,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Setup Java SDK
       uses: actions/setup-java@v4
       with:
@@ -50,14 +52,6 @@ jobs:
       run: dotnet workload install maui maui-android maui-ios maui-tizen maui-maccatalyst maui-windows android --source https://api.nuget.org/v3/index.json
     - name: list workloads
       run: dotnet workload list
-
-    - name: Ensure GitHub NuGet Source
-      run: dotnet nuget add source ${{ env.package_feed }} 
-            -n github 
-            -u ${{ secrets.NUGET_USER }} 
-            -p ${{ secrets.CONSUME_CALIBURN_FEED }} 
-            --store-password-in-clear-text
-      if: github.event_name != 'pull_request'
       
     - name: Restore nuget packages
       run:  msbuild ${{env.caliburn_sln}} -t:restore
@@ -65,7 +59,9 @@ jobs:
     - name: Build app for release
       run: msbuild ${{env.caliburn_sln}} /t:Build /p:Configuration=${{env.build_configuration}}
 
-      
+    - name: Run Unit Tests
+      run: dotnet test src/caliburn.micro.sln  --configuration release -p:CollectCoverage=true -p:CoverletOutputFormat=json --no-build --verbosity normal /p:MergeWith=..\Caliburn.Micro.Core.Tests\coverage.json /m:1   
+  
     - name: Restore nuget packages for tutorial
       run:  msbuild ${{env.caliburn_tutorial}} -t:restore 
       
@@ -82,5 +78,5 @@ jobs:
       run: msbuild ${{env.caliburn_sln}} /t:package /p:Configuration=${{env.build_configuration}}
       
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push ${{env.nuget_folder}}\**\*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
+      run: dotnet nuget push ${{env.nuget_upload}} --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
       if: github.event_name != 'pull_request'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -78,4 +78,4 @@ jobs:
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
-      #if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Setup Java SDK
       uses: actions/setup-java@v4
       with:

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -15,7 +15,7 @@ steps:
   displayName: 'Install .NET'
   inputs:
     packageType: 'sdk'
-    version: '8.0.x' 
+    version: '9.0.x' 
 
 
 - task: PowerShell@2

--- a/samples/features/Features.NetFive/Features.DotNet.csproj
+++ b/samples/features/Features.NetFive/Features.DotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AssemblyName>Features.CrossPlatform</AssemblyName>
     <RootNamespace>Features.CrossPlatform</RootNamespace>
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <Reference Include="Caliburn.Micro.Core">
-      <HintPath>..\..\..\bin\Caliburn.Micro.Platform\release\net8.0-windows\Caliburn.Micro.Core.dll</HintPath>
+      <HintPath>..\..\..\bin\Caliburn.Micro.Platform\release\net9.0-windows\Caliburn.Micro.Core.dll</HintPath>
     </Reference>
     <Reference Include="Caliburn.Micro.Platform">
-      <HintPath>..\..\..\bin\Caliburn.Micro.Platform\release\net8.0-windows\Caliburn.Micro.Platform.dll</HintPath>
+      <HintPath>..\..\..\bin\Caliburn.Micro.Platform\release\net9.0-windows\Caliburn.Micro.Platform.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/samples/setup/Setup.UWP/Setup.UWP.csproj
+++ b/samples/setup/Setup.UWP/Setup.UWP.csproj
@@ -127,7 +127,7 @@
       <Version>4.0.173</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.12</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/setup/Setup.WPF.Core.VB/Bootstrapper.vb
+++ b/samples/setup/Setup.WPF.Core.VB/Bootstrapper.vb
@@ -18,7 +18,7 @@ Public Class Bootstrapper
     End Sub
 
     Protected Overrides Sub OnStartup(sender As Object, e As StartupEventArgs)
-        DisplayRootViewFor(Of ShellViewModel)()
+        DisplayRootViewForAsync(Of ShellViewModel)()
     End Sub
 
     Protected Overrides Function GetInstance(service As Type, key As String) As Object

--- a/samples/setup/Setup.WPF.Core.VB/Setup.WPF.Core.VB.vbproj
+++ b/samples/setup/Setup.WPF.Core.VB/Setup.WPF.Core.VB.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <RootNamespace>Setup.WPF.Core.VB</RootNamespace>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
+    <PackageReference Include="Caliburn.Micro" Version="4.0.212" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/setup/Setup.WPF.Core/Bootstrapper.cs
+++ b/samples/setup/Setup.WPF.Core/Bootstrapper.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using Caliburn.Micro;
 using Setup.WPF.Core.ViewModels;
@@ -30,7 +27,7 @@ namespace Setup.WPF.Core
 
         protected override void OnStartup(object sender, StartupEventArgs e)
         {
-            DisplayRootViewFor<ShellViewModel>();
+            DisplayRootViewForAsync<ShellViewModel>();
         }
 
         protected override object GetInstance(Type service, string key)

--- a/samples/setup/Setup.WPF.Core/Setup.WPF.Core.csproj
+++ b/samples/setup/Setup.WPF.Core/Setup.WPF.Core.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
+    <PackageReference Include="Caliburn.Micro" Version="4.0.212" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorTests.cs
@@ -26,12 +26,12 @@ namespace Caliburn.Micro.Core.Tests
         {
             var handlerStub = new Mock<IHandle<object>>().Object;
             var aggregator = new EventAggregator();
-
-            Assert.False(aggregator.HandlerExistsFor(typeof(object)));
+            var messageType = typeof(object);
+            Assert.False(aggregator.HandlerExistsFor(messageType));
 
             aggregator.SubscribeOnPublishedThread(handlerStub);
 
-            Assert.True(aggregator.HandlerExistsFor(typeof(object)));
+            Assert.True(aggregator.HandlerExistsFor(messageType));
         }
     }
 

--- a/src/Caliburn.Micro.Core/EventAggregator.cs
+++ b/src/Caliburn.Micro.Core/EventAggregator.cs
@@ -10,6 +10,8 @@ namespace Caliburn.Micro
     /// <inheritdoc />
     public class EventAggregator : IEventAggregator
     {
+        private static readonly ILog Log = LogManager.GetLog(typeof(EventAggregator));
+
         private readonly List<Handler> _handlers = new List<Handler>();
 
         /// <inheritdoc />
@@ -17,6 +19,8 @@ namespace Caliburn.Micro
         {
             lock (_handlers)
             {
+                Log.Info("Checking if handler exists for {0}.", messageType.FullName);
+                Log.Info("There are {0} handlers registered.", _handlers.Count);
                 return _handlers.Any(handler => handler.Handles(messageType) && !handler.IsDead);
             }
         }
@@ -38,9 +42,10 @@ namespace Caliburn.Micro
             {
                 if (_handlers.Any(x => x.Matches(subscriber)))
                 {
+                    Log.Info("Message Handler exists");
                     return;
                 }
-
+                Log.Info("Message Handler Adding it");
                 _handlers.Add(new Handler(subscriber, marshal));
             }
         }

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;uap10.0.19041;net8.0-android;net8.0-ios;net8.0-windows;</TargetFrameworks>
+    <TargetFrameworks>net462;uap10.0.19041;net8.0-android;net8.0-ios;net9.0-android;net9.0-ios;net8.0-windows;net9.0-windows</TargetFrameworks>
     <PackageId>Caliburn.Micro</PackageId>
     <Product>Caliburn.Micro</Product>
     <RootNamespace>Caliburn.Micro</RootNamespace>
@@ -50,6 +50,10 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <Compile Include="Platforms\net46-netcore\**\*.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <Compile Include="Platforms\net46-netcore\**\*.cs" />
+  </ItemGroup>
 
   <ItemGroup Label="Package">
     <None Include="Platforms\uap\Caliburn.Micro.Platform.rd.xml" PackagePath="lib\uap10.0.16299\Caliburn.Micro.Platform\Properties\Caliburn.Micro.Platform.rd.xml" Pack="true" />
@@ -67,6 +71,18 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+    <Compile Remove="*.cs" />
+    <Compile Include="Platforms\ios\**\*.cs" />
+    <Compile Include="ViewModelLocator.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
+    <Compile Remove="*.cs" />
+    <Compile Include="Platforms\android\**\*.cs" />
+    <Compile Include="ViewModelLocator.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
     <Compile Remove="*.cs" />
     <Compile Include="Platforms\ios\**\*.cs" />
     <Compile Include="ViewModelLocator.cs" />

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.x",
+    "version": "9.0.x",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
This pull request includes updates to the `.NET` workflow and the `Caliburn.Micro.Platform` project file to support new .NET versions and improve the build and test processes. The most important changes include updating the .NET version, adding new target frameworks, and enhancing the workflow steps.

### Workflow updates:

* Updated the .NET version from `8.0.x` to `9.0.x` in the `.github/workflows/dotnet.yml` file.
* Added a step to run unit tests with coverage collection in the `.github/workflows/dotnet.yml` file.
* Simplified the NuGet package push command by using a new environment variable in the `.github/workflows/dotnet.yml` file.

### Project file updates:

* Added `net9.0-android`, `net9.0-ios`, and `net9.0-windows` to the `TargetFrameworks` in the `Caliburn.Micro.Platform.csproj` file.
* Added conditional `ItemGroup`s for `net9.0-windows`, `net9.0-android`, and `net9.0-ios` to include platform-specific source files in the `Caliburn.Micro.Platform.csproj` file. [[1]](diffhunk://#diff-4830d5140b500c825dbd6742825586f3499939d5a9bd3eab73e60cbdfa5d48c0R53-R56) [[2]](diffhunk://#diff-4830d5140b500c825dbd6742825586f3499939d5a9bd3eab73e60cbdfa5d48c0R79-R90)

Closing #930 