### PR TITLE
Refactor parameter names and simplify iteration

### DIFF
--- a/src/Caliburn.Micro.Core/ContinueResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/ContinueResultDecorator.cs
@@ -29,10 +29,10 @@ namespace Caliburn.Micro
         /// <summary>
         /// Called when the execution of the decorated result has completed.
         /// </summary>
-        /// <param name="context">The context.</param>
+        /// <param name="methodContext">The context.</param>
         /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext methodContext, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             if (args.Error != null || !args.WasCancelled)
             {
@@ -41,7 +41,7 @@ namespace Caliburn.Micro
             else
             {
                 Log.Info(string.Format("Executing coroutine because {0} was cancelled.", methodInnerResult.GetType().Name));
-                Continue(context);
+                Continue(methodContext);
             }
         }
 

--- a/src/Caliburn.Micro.Core/ContinueResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/ContinueResultDecorator.cs
@@ -30,9 +30,9 @@ namespace Caliburn.Micro
         /// Called when the execution of the decorated result has completed.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="innerResult">The decorated result.</param>
+        /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult innerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             if (args.Error != null || !args.WasCancelled)
             {
@@ -40,7 +40,7 @@ namespace Caliburn.Micro
             }
             else
             {
-                Log.Info(string.Format("Executing coroutine because {0} was cancelled.", innerResult.GetType().Name));
+                Log.Info(string.Format("Executing coroutine because {0} was cancelled.", methodInnerResult.GetType().Name));
                 Continue(context);
             }
         }

--- a/src/Caliburn.Micro.Core/OverrideCancelResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/OverrideCancelResultDecorator.cs
@@ -17,10 +17,10 @@
         /// <summary>
         /// Called when the execution of the decorated result has completed.
         /// </summary>
-        /// <param name="context">The context.</param>
+        /// <param name="methodContext">The context.</param>
         /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext methodContext, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             if (args.WasCancelled)
             {

--- a/src/Caliburn.Micro.Core/OverrideCancelResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/OverrideCancelResultDecorator.cs
@@ -18,13 +18,13 @@
         /// Called when the execution of the decorated result has completed.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="innerResult">The decorated result.</param>
+        /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult innerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             if (args.WasCancelled)
             {
-                Log.Info(string.Format("Overriding WasCancelled from {0}.", innerResult.GetType().Name));
+                Log.Info(string.Format("Overriding WasCancelled from {0}.", methodInnerResult.GetType().Name));
             }
 
             OnCompleted(new ResultCompletionEventArgs { Error = args.Error });

--- a/src/Caliburn.Micro.Core/RescueResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/RescueResultDecorator.cs
@@ -28,9 +28,9 @@ namespace Caliburn.Micro
         /// Called when the execution of the decorated result has completed.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="innerResult">The decorated result.</param>
+        /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult innerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             var error = args.Error as TException;
             if (error == null)
@@ -40,7 +40,7 @@ namespace Caliburn.Micro
             else
             {
                 Log.Error(error);
-                Log.Info(string.Format("Executing coroutine because {0} threw an exception.", innerResult.GetType().Name));
+                Log.Info(string.Format("Executing coroutine because {0} threw an exception.", methodInnerResult.GetType().Name));
                 Rescue(context, error);
             }
         }

--- a/src/Caliburn.Micro.Core/RescueResultDecorator.cs
+++ b/src/Caliburn.Micro.Core/RescueResultDecorator.cs
@@ -27,10 +27,10 @@ namespace Caliburn.Micro
         /// <summary>
         /// Called when the execution of the decorated result has completed.
         /// </summary>
-        /// <param name="context">The context.</param>
+        /// <param name="methodContext">The context.</param>
         /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs" /> instance containing the event data.</param>
-        protected override void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args)
+        protected override void OnInnerResultCompleted(CoroutineExecutionContext methodContext, IResult methodInnerResult, ResultCompletionEventArgs args)
         {
             var error = args.Error as TException;
             if (error == null)
@@ -41,7 +41,7 @@ namespace Caliburn.Micro
             {
                 Log.Error(error);
                 Log.Info(string.Format("Executing coroutine because {0} threw an exception.", methodInnerResult.GetType().Name));
-                Rescue(context, error);
+                Rescue(methodContext, error);
             }
         }
 

--- a/src/Caliburn.Micro.Core/ResultDecoratorBase.cs
+++ b/src/Caliburn.Micro.Core/ResultDecoratorBase.cs
@@ -49,10 +49,10 @@ namespace Caliburn.Micro
         /// <summary>
         /// Called when the execution of the decorated result has completed.
         /// </summary>
-        /// <param name="context">The context.</param>
+        /// <param name="methodContext">The context.</param>
         /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs"/> instance containing the event data.</param>
-        protected abstract void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args);
+        protected abstract void OnInnerResultCompleted(CoroutineExecutionContext methodContext, IResult methodInnerResult, ResultCompletionEventArgs args);
 
         /// <summary>
         /// Occurs when execution has completed.

--- a/src/Caliburn.Micro.Core/ResultDecoratorBase.cs
+++ b/src/Caliburn.Micro.Core/ResultDecoratorBase.cs
@@ -50,9 +50,9 @@ namespace Caliburn.Micro
         /// Called when the execution of the decorated result has completed.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="innerResult">The decorated result.</param>
+        /// <param name="methodInnerResult">The decorated result.</param>
         /// <param name="args">The <see cref="ResultCompletionEventArgs"/> instance containing the event data.</param>
-        protected abstract void OnInnerResultCompleted(CoroutineExecutionContext context, IResult innerResult, ResultCompletionEventArgs args);
+        protected abstract void OnInnerResultCompleted(CoroutineExecutionContext context, IResult methodInnerResult, ResultCompletionEventArgs args);
 
         /// <summary>
         /// Occurs when execution has completed.

--- a/src/Caliburn.Micro.Platform/Bind.cs
+++ b/src/Caliburn.Micro.Platform/Bind.cs
@@ -265,7 +265,7 @@ namespace Caliburn.Micro
                 return;
 
             var enable = d.GetValue(AtDesignTimeProperty);
-            if (enable == null || ((bool)enable) == false || e.NewValue == null)
+            if (enable == null || !((bool)enable) || e.NewValue == null)
                 return;
 
             var fe = d as FrameworkElement;

--- a/src/Caliburn.Micro.Platform/Platforms/Maui/HttpUtility.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/HttpUtility.cs
@@ -46,7 +46,6 @@ namespace Caliburn.Micro.Maui
                 if (count == 0)
                     return "";
                 StringBuilder sb = new StringBuilder();
-                var keys = this.Keys;
                 foreach (var key in this.Keys)
                 {
                     sb.AppendFormat("{0}={1}&", key, this[key]);


### PR DESCRIPTION
Changed parameter name `innerResult` to `methodInnerResult` in `OnInnerResultCompleted` method across multiple files in the `Caliburn.Micro` namespace for consistency:
- `ContinueResultDecorator.cs`
- `OverrideCancelResultDecorator.cs`
- `RescueResultDecorator.cs`
- `ResultDecoratorBase.cs`

Removed unnecessary variable `keys` in `HttpUtility.cs` within the `Caliburn.Micro.Maui` namespace, directly iterating over `this.Keys` in the `foreach` loop to simplify the code.

Closes #940
Closes #939