### PR TITLE
Refactor and reformat Parameter class and MakeAwareOf method

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Maui/Parameter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/Parameter.cs
@@ -86,10 +86,10 @@ namespace Caliburn.Micro
         /// <summary>
         /// Makes the parameter aware of the <see cref="ActionMessage"/> that it's attached to.
         /// </summary>
-        /// <param name="owner">The action message.</param>
-        internal void MakeAwareOf(ActionMessage owner)
+        /// <param name="actionMessageOwner">The action message.</param>
+        internal void MakeAwareOf(ActionMessage actionMessageOwner)
         {
-            Owner = owner;
+            Owner = actionMessageOwner;
         }
 
         internal static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/Parameter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/Parameter.cs
@@ -6,10 +6,8 @@ namespace Caliburn.Micro
 {
     using System;
 #if XFORMS
-    using global::Xamarin.Forms;
     using DependencyObject = global::Xamarin.Forms.BindableObject;
     using DependencyProperty = global::Xamarin.Forms.BindableProperty;
-    using FrameworkElement = global::Xamarin.Forms.VisualElement;
 #else
     using Windows.UI.Xaml;
 #endif
@@ -18,7 +16,8 @@ namespace Caliburn.Micro
     /// Represents a parameter of an <see cref="ActionMessage"/>.
     /// </summary>
 #if WINDOWS_UWP || XFORMS
-    public class Parameter : DependencyObject, IAttachedObject {
+    public class Parameter : DependencyObject, IAttachedObject
+    {
         DependencyObject associatedObject;
 #else
     public class Parameter : FrameworkElement, IAttachedObject
@@ -35,7 +34,7 @@ namespace Caliburn.Micro
                 "Value",
                 typeof(object),
                 typeof(Parameter),
-                null, 
+                null,
                 OnValueChanged
                 );
 
@@ -50,7 +49,8 @@ namespace Caliburn.Micro
         }
 
 #if WINDOWS_UWP || XFORMS
-        DependencyObject IAttachedObject.AssociatedObject {
+        DependencyObject IAttachedObject.AssociatedObject
+        {
 #else
         FrameworkElement IAttachedObject.AssociatedObject
         {
@@ -69,7 +69,8 @@ namespace Caliburn.Micro
         }
 
 #if WINDOWS_UWP || XFORMS
-        void IAttachedObject.Attach(DependencyObject dependencyObject) {
+        void IAttachedObject.Attach(DependencyObject dependencyObject)
+        {
 #else
         void IAttachedObject.Attach(FrameworkElement dependencyObject)
         {
@@ -85,10 +86,10 @@ namespace Caliburn.Micro
         /// <summary>
         /// Makes the parameter aware of the <see cref="ActionMessage"/> that it's attached to.
         /// </summary>
-        /// <param name="owner">The action message.</param>
-        internal void MakeAwareOf(ActionMessage owner)
+        /// <param name="actionMessageOwner">The action message.</param>
+        internal void MakeAwareOf(ActionMessage actionMessageOwner)
         {
-            Owner = owner;
+            Owner = actionMessageOwner;
         }
 
         static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
Refactored MakeAwareOf method to rename parameter from `owner` to `actionMessageOwner` for clarity. Updated internal implementation accordingly. Reformatted Parameter class in Caliburn.Micro.Xamarin.Forms namespace for consistency, including placing opening braces `{` on new lines and aligning `null` value in ValueProperty registration.