### PR TITLE
Refactor conditional assignment to use ternary operator

### DIFF
--- a/src/Caliburn.Micro.Platform/MessageBinder.cs
+++ b/src/Caliburn.Micro.Platform/MessageBinder.cs
@@ -80,11 +80,10 @@ namespace Caliburn.Micro
                 var parameterValue = providedValues[i];
                 var parameterAsString = parameterValue as string;
 
-                if (parameterAsString != null)
-                    finalValues[i] = CoerceValue(parameterType,
-                        EvaluateParameter(parameterAsString, parameterType, context), context);
-                else
-                    finalValues[i] = CoerceValue(parameterType, parameterValue, context);
+                finalValues[i] = (parameterAsString != null) ?
+                    CoerceValue(parameterType,
+                        EvaluateParameter(parameterAsString, parameterType, context), context) :
+                    CoerceValue(parameterType, parameterValue, context);
             }
 
             return finalValues;


### PR DESCRIPTION
Replaced the `if-else` statement with a ternary conditional operator for assigning `finalValues[i]`. This change makes the code more concise by combining the condition and assignment into a single line, improving readability and maintainability.