### PR TITLE
952 fix code scanning alert useless assignment to local variable

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
@@ -54,7 +54,7 @@
         public virtual void BeginOnUIThread(System.Action action)
         {
             ValidateDispatcher();
-            var dummy = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
+            _ = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
         }
 
         /// <summary>

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/HttpUtility.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/HttpUtility.cs
@@ -44,7 +44,6 @@ namespace Caliburn.Micro.Xamarin.Forms
                 if (count == 0)
                     return "";
                 StringBuilder sb = new StringBuilder();
-                var keys = this.Keys;
                 foreach (var key in this.Keys)
                 {
                     sb.AppendFormat("{0}={1}&", key, this[key]);

--- a/src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+﻿//
 // Copyright (c) 2012 Tim Heuer
 //
 // Licensed under the Microsoft Public License (Ms-PL) (the "License");
@@ -49,8 +49,8 @@ namespace Caliburn.Micro
                                          SmallLogoUri = new Uri(string.Format("ms-appx:///{0}", vel.Attribute("Square30x30Logo").Value.Replace(@"\", @"/"))),
                                          BackgroundColorAsString = vel.Attribute("BackgroundColor").Value
                                      }).FirstOrDefault();
-            
-            if (visualElementNode == null) 
+
+            if (visualElementNode == null)
                 throw new ArgumentNullException("Could not parse the VisualElements from the app manifest.");
 
             return visualElementNode;
@@ -79,7 +79,7 @@ namespace Caliburn.Micro
             // in order to prevent parsing failures
             if (String.Equals(hexValue, "transparent", StringComparison.OrdinalIgnoreCase))
                 return Windows.UI.Colors.Transparent;
-                
+
             hexValue = hexValue.Replace("#", string.Empty);
 
             // some loose validation (not bullet-proof)
@@ -88,23 +88,14 @@ namespace Caliburn.Micro
                 throw new ArgumentException("This does not appear to be a proper hex color number");
             }
 
-            byte a = 255;
-            byte r = 255;
-            byte g = 255;
-            byte b = 255;
+            byte a = (hexValue.Length == 8) ? byte.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber) : (byte)255;
 
-            int startPosition = 0;
 
-            // the case where alpha is provided
-            if (hexValue.Length == 8)
-            {
-                a = byte.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber);
-                startPosition = 2;
-            }
+            int startPosition = (hexValue.Length == 8) ? 2 : 0;
 
-            r = byte.Parse(hexValue.Substring(startPosition, 2), NumberStyles.HexNumber);
-            g = byte.Parse(hexValue.Substring(startPosition + 2, 2), NumberStyles.HexNumber);
-            b = byte.Parse(hexValue.Substring(startPosition + 4, 2), NumberStyles.HexNumber);
+            byte r = byte.Parse(hexValue.Substring(startPosition, 2), NumberStyles.HexNumber);
+            byte g = byte.Parse(hexValue.Substring(startPosition + 2, 2), NumberStyles.HexNumber);
+            byte b = byte.Parse(hexValue.Substring(startPosition + 4, 2), NumberStyles.HexNumber);
 
             return Windows.UI.Color.FromArgb(a, r, g, b);
         }

--- a/src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs
@@ -1,5 +1,4 @@
-﻿//
-// Copyright (c) 2012 Tim Heuer
+﻿// Copyright (c) 2012 Tim Heuer
 //
 // Licensed under the Microsoft Public License (Ms-PL) (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 using System;
 using System.Globalization;

--- a/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Caliburn.Micro {
+﻿namespace Caliburn.Micro
+{
     using System;
     using System.Collections.Generic;
     using System.Threading;
@@ -19,7 +20,8 @@
     /// <summary>
     /// A <see cref="IPlatformProvider"/> implementation for the XAML platfrom.
     /// </summary>
-    public class XamlPlatformProvider : IPlatformProvider {
+    public class XamlPlatformProvider : IPlatformProvider
+    {
 #if WINDOWS_UWP
         private readonly CoreDispatcher dispatcher;
 #else
@@ -29,7 +31,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="XamlPlatformProvider"/> class.
         /// </summary>
-        public XamlPlatformProvider() {
+        public XamlPlatformProvider()
+        {
 #if WINDOWS_UWP
             dispatcher = Window.Current.Dispatcher;
 #elif AVALONIA
@@ -47,16 +50,19 @@
         /// <summary>
         /// Indicates whether or not the framework is in design-time mode.
         /// </summary>
-        public virtual bool InDesignMode {
+        public virtual bool InDesignMode
+        {
             get { return View.InDesignMode; }
         }
 
-        private void ValidateDispatcher() {
+        private void ValidateDispatcher()
+        {
             if (dispatcher == null)
                 throw new InvalidOperationException("Not initialized with dispatcher.");
         }
 
-        private bool CheckAccess() {
+        private bool CheckAccess()
+        {
 #if WINDOWS_UWP
             return dispatcher == null || Window.Current != null;
 #else
@@ -68,10 +74,11 @@
         /// Executes the action on the UI thread asynchronously.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        public virtual void BeginOnUIThread(System.Action action) {
+        public virtual void BeginOnUIThread(System.Action action)
+        {
             ValidateDispatcher();
 #if WINDOWS_UWP
-            var dummy = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
+            _ = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
 #elif AVALONIA
             dispatcher.Post(action);
 #else
@@ -84,7 +91,8 @@
         /// </summary>
         /// <param name="action">The action to execute.</param>
         /// <returns></returns>
-        public virtual Task OnUIThreadAsync(Func<Task> action) {
+        public virtual Task OnUIThreadAsync(Func<Task> action)
+        {
             ValidateDispatcher();
 #if WINDOWS_UWP
             return dispatcher.RunTaskAsync(action);
@@ -100,19 +108,24 @@
         /// </summary>
         /// <param name="action">The action to execute.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public virtual void OnUIThread(System.Action action) {
+        public virtual void OnUIThread(System.Action action)
+        {
             if (CheckAccess())
                 action();
-            else {
+            else
+            {
 #if WINDOWS_UWP
                 dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).AsTask().Wait();
 #else
                 Exception exception = null;
-                System.Action method = () => {
-                    try {
+                System.Action method = () =>
+                {
+                    try
+                    {
                         action();
                     }
-                    catch(Exception ex) {
+                    catch (Exception ex)
+                    {
                         exception = ex;
                     }
                 };
@@ -120,7 +133,7 @@
                 dispatcher.Invoke(method);
 
                 if (exception != null)
-                throw new System.Reflection.TargetInvocationException("An error occurred while dispatching a call to the UI Thread", exception);
+                    throw new System.Reflection.TargetInvocationException("An error occurred while dispatching a call to the UI Thread", exception);
 #endif
             }
         }
@@ -138,7 +151,8 @@
         /// The WindowManager marks that element as a framework-created element so that it can determine what it created vs. what was intended by the developer.
         /// Calling GetFirstNonGeneratedView allows the framework to discover what the original element was.
         /// </remarks>
-        public virtual object GetFirstNonGeneratedView(object view) {
+        public virtual object GetFirstNonGeneratedView(object view)
+        {
             return View.GetFirstNonGeneratedView(view);
         }
 
@@ -158,9 +172,11 @@
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="handler">The handler.</param>
-        public virtual void ExecuteOnFirstLoad(object view, Action<object> handler) {
+        public virtual void ExecuteOnFirstLoad(object view, Action<object> handler)
+        {
             var element = view as FrameworkElement;
-            if (element != null && !(bool) element.GetValue(PreviouslyAttachedProperty)) {
+            if (element != null && !(bool)element.GetValue(PreviouslyAttachedProperty))
+            {
                 element.SetValue(PreviouslyAttachedProperty, true);
                 View.ExecuteOnLoad(element, (s, e) => handler(s));
             }
@@ -171,9 +187,11 @@
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="handler">The handler.</param>
-        public virtual void ExecuteOnLayoutUpdated(object view, Action<object> handler) {
+        public virtual void ExecuteOnLayoutUpdated(object view, Action<object> handler)
+        {
             var element = view as FrameworkElement;
-            if (element != null) {
+            if (element != null)
+            {
                 View.ExecuteOnLayoutUpdated(element, (s, e) => handler(s));
             }
         }
@@ -190,7 +208,8 @@
         /// <exception cref="System.NotImplementedException"></exception>
         public virtual Func<CancellationToken, Task> GetViewCloseAction(object viewModel, ICollection<object> views, bool? dialogResult)
         {
-            foreach (var contextualView in views) {
+            foreach (var contextualView in views)
+            {
                 var viewType = contextualView.GetType();
 #if WINDOWS_UWP
                 var closeMethod = viewType.GetRuntimeMethod("Close", new Type[0]);
@@ -200,7 +219,8 @@
                 var closeMethod = viewType.GetMethod("Close", new Type[0]);
 #endif
                 if (closeMethod != null)
-                    return ct => {
+                    return ct =>
+                    {
 #if AVALONIA
                         if (dialogResult != null)
                         {
@@ -234,7 +254,8 @@
 #else
                 var isOpenProperty = viewType.GetProperty("IsOpen");
 #endif
-                if (isOpenProperty != null) {
+                if (isOpenProperty != null)
+                {
                     return ct =>
                     {
                         isOpenProperty.SetValue(contextualView, false, null);


### PR DESCRIPTION
This pull request includes several changes to improve code readability and maintainability across multiple files by reformatting code and removing unnecessary variables.

### Code readability improvements:

* [`src/Caliburn.Micro.Platform/XamlPlatformProvider.cs`](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L1-R2): Reformatted the class to follow consistent brace placement and spacing conventions. This includes moving opening braces to a new line and ensuring proper spacing around operators and keywords. [[1]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L1-R2) [[2]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L22-R24) [[3]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L32-R35) [[4]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L50-R65) [[5]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L71-R81) [[6]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L87-R95) [[7]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L103-R128) [[8]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L141-R155) [[9]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L161-R179) [[10]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L174-R194) [[11]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L193-R212) [[12]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L203-R223) [[13]](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L237-R258)

### Code maintainability improvements:

* [`src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs`](diffhunk://#diff-2964fde80013220cb938e0fe0feab2653df6e7d2c38c718eae7d992ea6bc9d43L57-R57): Removed the unused variable `dummy` in the `BeginOnUIThread` method and replaced it with a discard `_`.

* [`src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/HttpUtility.cs`](diffhunk://#diff-252529913c6a6d194901f70eab963e414ce6174caa3db269fe11c53548427eecL47): Removed the redundant variable `keys` in the `ToString` method.
* [`src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs`](diffhunk://#diff-a69165932ae7d7246181c9732fa78f17bd7e84d50c5952ec91dd2230624fde17L91-R98): Simplified the `ToColor` method by removing redundant variable declarations and consolidating the logic for parsing hex color values.

### Miscellaneous:

* [`src/Caliburn.Micro.Platform/Platforms/uap/AppManifestHelper.cs`](diffhunk://#diff-a69165932ae7d7246181c9732fa78f17bd7e84d50c5952ec91dd2230624fde17L1-R1): Fixed a minor formatting issue in the file header comment.


closes #952  #954 #955 #956 #957 