### PR TITLE
Potential fix for code scanning alert no. 82: Missed opportunity to use Where

### DIFF
--- a/src/Caliburn.Micro.Core/SimpleContainer.cs
+++ b/src/Caliburn.Micro.Core/SimpleContainer.cs
@@ -181,12 +181,9 @@ namespace Caliburn.Micro
 
             var instances = currentEntry.Select(e => e(this));
 
-            foreach (var instance in instances)
+            foreach (var instance in instances.Where(instance => EnablePropertyInjection && instance != null))
             {
-                if (EnablePropertyInjection && instance != null)
-                {
-                    BuildUp(instance);
-                }
+                BuildUp(instance);
             }
 
             return instances;


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/82](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/82)

To fix the issue, we will replace the `foreach` loop on line 184 with a LINQ `Where` clause applied to the `instances` sequence. This will explicitly filter the sequence before iterating over it, making the code more readable and reducing nesting depth. The filtering condition `EnablePropertyInjection && instance != null` will be moved to the `Where` method.

No new methods, imports, or definitions are required to implement this change, as LINQ is already imported (`using System.Linq`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
