### PR TITLE
Update XamlPlatformProvider.cs

### DIFF
--- a/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/XamlPlatformProvider.cs
@@ -83,11 +83,11 @@ namespace Caliburn.Micro {
         public virtual void BeginOnUIThread(System.Action action) {
             ValidateDispatcher();
 #if WINDOWS_UWP 
-            var dummy = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
+            _ = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
 #elif AVALONIA
             dispatcher.Post(action);
 #elif WinUI3
-            var dummy = dispatcher.TryEnqueue(() => action());
+            _ = dispatcher.TryEnqueue(() => action());
 #else
             dispatcher.BeginInvoke(action);
 #endif


### PR DESCRIPTION
This pull request includes a minor change to the `BeginOnUIThread` method in the `XamlPlatformProvider` class. The change replaces unused variable assignments with a discard operator (`_`) to improve code clarity and avoid compiler warnings.

* [`src/Caliburn.Micro.Platform/XamlPlatformProvider.cs`](diffhunk://#diff-e59da2c086282eba687b327fa754d131cb99e25992ea8ecf2657faddc01f49b6L86-R90): Replaced unused variable `dummy` with the discard operator (`_`) in both `dispatcher.RunAsync` and `dispatcher.TryEnqueue` calls.