### PR TITLE
Potential fix for code scanning alert no. 67: Nested 'if' statements can be combined

### DIFF
--- a/src/Caliburn.Micro.Platform/Parser.cs
+++ b/src/Caliburn.Micro.Platform/Parser.cs
@@ -282,16 +282,13 @@ namespace Caliburn.Micro
             var core = messageText.Substring(0, openingParenthesisIndex).Trim();
             var message = InterpretMessageText(target, core);
             var withParameters = message as IHaveParameters;
-            if (withParameters != null)
+            if (withParameters != null && closingParenthesisIndex - openingParenthesisIndex > 1)
             {
-                if (closingParenthesisIndex - openingParenthesisIndex > 1)
-                {
-                    var paramString = messageText.Substring(openingParenthesisIndex + 1, closingParenthesisIndex - openingParenthesisIndex - 1);
-                    var parameters = StringSplitter.SplitParameters(paramString);
+                var paramString = messageText.Substring(openingParenthesisIndex + 1, closingParenthesisIndex - openingParenthesisIndex - 1);
+                var parameters = StringSplitter.SplitParameters(paramString);
 
-                    foreach (var parameter in parameters)
-                        withParameters.Parameters.Add(CreateParameter(target, parameter.Trim()));
-                }
+                foreach (var parameter in parameters)
+                    withParameters.Parameters.Add(CreateParameter(target, parameter.Trim()));
             }
 
             return message;


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/67](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/67)

To fix the issue, the nested `if` statements should be combined into a single `if` statement using the `&&` operator. This simplifies the code and eliminates unnecessary nesting. The conditions should be enclosed in parentheses to ensure correct operator precedence.

The specific change involves combining the `if (withParameters != null)` and `if (closingParenthesisIndex - openingParenthesisIndex > 1)` statements into a single `if` statement. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
