### PR TITLE
Simplify async call by removing unused variable

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/Windows/MauiPlatformProvider.cs
@@ -54,7 +54,7 @@
         public virtual void BeginOnUIThread(System.Action action)
         {
             ValidateDispatcher();
-            var dummy = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
+            _ = dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action());
         }
 
         /// <summary>


### PR DESCRIPTION
Removed the assignment of the result from `dispatcher.RunAsync` to a variable. The discard operator `_` is now used to indicate that the result is not needed, streamlining the code.