### PR TITLE
Refactor AddChildResolver for SplitView

### DIFF
--- a/src/Caliburn.Micro.Platform/BindingScope.cs
+++ b/src/Caliburn.Micro.Platform/BindingScope.cs
@@ -67,7 +67,7 @@
             AddChildResolver<SplitView>(e => new[] { e.Pane, e.Content });
 #endif
 #if WINDOWS_UWP || WinUI3
-            AddChildResolver<SplitView>(e => new[] { e.Pane as DependencyObject, e.Content as DependencyObject });
+            AddChildResolver<SplitView>(e => new[] { e.Pane, e.Content });
 #endif
         }
 


### PR DESCRIPTION
Removed unnecessary type casts for e.Pane and e.Content in the AddChildResolver<SplitView> method, simplifying the code and improving type safety.