### PR TITLE
Potential fix for code scanning alert no. 73: Nested 'if' statements can be combined

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/uap/AttachedCollection.81.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/AttachedCollection.81.cs
@@ -65,8 +65,9 @@
         /// </summary>
         /// <param name="item">The item that was removed.</param>
         protected virtual void OnItemRemoved(DependencyObject item) {
-            if (item is IAttachedObject && ((IAttachedObject)item).AssociatedObject != null) {
-                ((IAttachedObject)item).Detach();
+            var attached = item as IAttachedObject;
+            if (attached != null && attached.AssociatedObject != null) {
+                attached.Detach();
             }
         }
 

--- a/src/Caliburn.Micro.Platform/Platforms/uap/AttachedCollection.81.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/AttachedCollection.81.cs
@@ -65,9 +65,8 @@
         /// </summary>
         /// <param name="item">The item that was removed.</param>
         protected virtual void OnItemRemoved(DependencyObject item) {
-            if (item is IAttachedObject) {
-                if (((IAttachedObject) item).AssociatedObject != null)
-                    ((IAttachedObject) item).Detach();
+            if (item is IAttachedObject && ((IAttachedObject)item).AssociatedObject != null) {
+                ((IAttachedObject)item).Detach();
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/73](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/73)

To fix the issue, the nested `if` statements on lines 68-70 should be combined into a single `if` statement. The conditions `item is IAttachedObject` and `((IAttachedObject)item).AssociatedObject != null` should be joined using the `&&` operator. Parentheses should be used around each condition to ensure proper operator precedence and maintain clarity. This change will simplify the code while preserving its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
