### PR TITLE
Potential fix for code scanning alert no. 19: Useless assignment to local variable

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/HttpUtility.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/HttpUtility.cs
@@ -44,7 +44,6 @@ namespace Caliburn.Micro.Xamarin.Forms
                 if (count == 0)
                     return "";
                 StringBuilder sb = new StringBuilder();
-                var keys = this.Keys;
                 foreach (var key in this.Keys)
                 {
                     sb.AppendFormat("{0}={1}&", key, this[key]);


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/19](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/19)

To fix the issue, the assignment to the variable `keys` on line 47 should be removed entirely. The `foreach` loop already accesses `this.Keys` directly, so the variable `keys` is unnecessary. This change will eliminate the redundant assignment and improve code clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
