### PR TITLE
Potential fix for code scanning alert no. 1: Call to GC.Collect()

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/net46-netcore/FrameAdapter.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/net46-netcore/FrameAdapter.cs
@@ -118,7 +118,6 @@ namespace Caliburn.Micro
                 await activator.ActivateAsync();
             }
 
-            GC.Collect();
         }
 
         /// <summary>


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/1](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/1)

To fix the issue, the explicit call to `GC.Collect()` on line 121 should be removed. This will allow the garbage collector to manage memory automatically without interference. If the application uses unmanaged resources, ensure they are properly disposed of using the `IDisposable` pattern and `try`/`finally` blocks. No additional changes are required in this specific method unless there is evidence of unmanaged resource usage elsewhere in the class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
