### PR TITLE
Potential fix for code scanning alert no. 253: Nested 'if' statements can be combined

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
@@ -425,13 +425,11 @@
                             {
                                 foreach (var key in _enumValues.Keys)
                                 {
-                                    if (String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0)
+                                    if (String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0 &&
+                                        _enumValues.TryGetValue(key.Trim(), out partValue))
                                     {
-                                        if (_enumValues.TryGetValue(key.Trim(), out partValue))
-                                        {
-                                            enumFieldValue = Convert.ToInt32(partValue);
-                                            break;
-                                        }
+                                        enumFieldValue = Convert.ToInt32(partValue);
+                                        break;
                                     }
                                 }
                             }


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/253](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/253)

To fix the issue, the nested `if` statements should be combined into a single `if` statement using the `&&` operator. This will reduce unnecessary nesting and make the code more concise. Specifically, the condition `if (String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0)` and the inner condition `if (_enumValues.TryGetValue(key.Trim(), out partValue))` should be combined into a single `if` statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
