### PR TITLE
Potential fix for code scanning alert no. 194: Missed opportunity to use Where

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/uap/XamlMetadataProvider.cs
@@ -423,15 +423,12 @@
                             }
                             catch (FormatException)
                             {
-                                foreach (var key in _enumValues.Keys)
+                                foreach (var key in _enumValues.Keys.Where(key => String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0))
                                 {
-                                    if (String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0)
+                                    if (_enumValues.TryGetValue(key.Trim(), out partValue))
                                     {
-                                        if (_enumValues.TryGetValue(key.Trim(), out partValue))
-                                        {
-                                            enumFieldValue = Convert.ToInt32(partValue);
-                                            break;
-                                        }
+                                        enumFieldValue = Convert.ToInt32(partValue);
+                                        break;
                                     }
                                 }
                             }


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/194](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/194)

To fix the issue, the `foreach` loop on line 426 should be replaced with a LINQ `Where` clause to filter `_enumValues.Keys` explicitly before iterating over them. This change will make the filtering condition more readable and reduce nesting within the loop body.

**Steps to implement the fix:**
1. Replace the `foreach` loop with a LINQ query that uses `Where` to filter `_enumValues.Keys` based on the condition `String.Compare(valuePart.Trim(), key, StringComparison.OrdinalIgnoreCase) == 0`.
2. Ensure the rest of the loop logic remains unchanged.
3. No additional imports or dependencies are required, as LINQ is part of the standard .NET library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
