### PR TITLE
Potential fix for code scanning alert no. 71: Nested 'if' statements can be combined

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
@@ -55,9 +55,8 @@
         /// </summary>
         /// <param name="item">The item that was removed.</param>
         protected virtual void OnItemRemoved(BindableObject item) {
-            if (item is IAttachedObject) {
-                if (((IAttachedObject) item).AssociatedObject != null)
-                    ((IAttachedObject) item).Detach();
+            if (item is IAttachedObject && ((IAttachedObject) item).AssociatedObject != null) {
+                ((IAttachedObject) item).Detach();
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/71](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/71)

To fix the issue, the nested `if` statements on line 58 and 59 should be combined into a single `if` statement using the `&&` operator. This will simplify the code and eliminate unnecessary nesting. The conditions should be enclosed in parentheses to ensure correct operator precedence.

The specific change involves replacing:
```cs
if (item is IAttachedObject) {
    if (((IAttachedObject) item).AssociatedObject != null)
        ((IAttachedObject) item).Detach();
}
```
with:
```cs
if (item is IAttachedObject && ((IAttachedObject) item).AssociatedObject != null) {
    ((IAttachedObject) item).Detach();
}
```

No additional methods, imports, or definitions are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
