### PR TITLE
Refactor AttachedCollection for readability and clarity

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/Maui/AttachedCollection.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/AttachedCollection.cs
@@ -1,6 +1,5 @@
-﻿namespace Caliburn.Micro.Maui 
+﻿namespace Caliburn.Micro.Maui
 {
-    using System;
     using System.Collections.Specialized;
     using System.Linq;
     using global::Microsoft.Maui.Controls;
@@ -10,7 +9,7 @@
     /// </summary>
     /// <typeparam name="T">The type of item in the attached collection.</typeparam>
     public class AttachedCollection<T> : BindableCollection<BindableObject>, IAttachedObject
-        where T : BindableObject, IAttachedObject 
+        where T : BindableObject, IAttachedObject
     {
         private BindableObject associatedObject;
 
@@ -27,7 +26,8 @@
         /// <summary>
         /// Detaches the collection.
         /// </summary>
-        public void Detach() {
+        public void Detach()
+        {
             this.OfType<IAttachedObject>().Apply(x => x.Detach());
             associatedObject = null;
         }
@@ -35,7 +35,8 @@
         /// <summary>
         /// The currently attached object.
         /// </summary>
-        public BindableObject AssociatedObject {
+        public BindableObject AssociatedObject
+        {
             get { return associatedObject; }
         }
 
@@ -43,10 +44,11 @@
         /// Called when an item is added from the collection.
         /// </summary>
         /// <param name="item">The item that was added.</param>
-        protected virtual void OnItemAdded(BindableObject item) {
-            if (associatedObject != null) {
-                if (item is IAttachedObject)
-                    ((IAttachedObject) item).Attach(associatedObject);
+        protected virtual void OnItemAdded(BindableObject item)
+        {
+            if (associatedObject != null && item is IAttachedObject)
+            {
+                ((IAttachedObject)item).Attach(associatedObject);
             }
         }
 
@@ -54,10 +56,12 @@
         /// Called when an item is removed from the collection.
         /// </summary>
         /// <param name="item">The item that was removed.</param>
-        protected virtual void OnItemRemoved(BindableObject item) {
-            if (item is IAttachedObject) {
-                if (((IAttachedObject) item).AssociatedObject != null)
-                    ((IAttachedObject) item).Detach();
+        protected virtual void OnItemRemoved(BindableObject item)
+        {
+            if (item is IAttachedObject &&
+                ((IAttachedObject)item).AssociatedObject != null)
+            {
+                ((IAttachedObject)item).Detach();
             }
         }
 
@@ -65,7 +69,8 @@
         /// Raises the <see cref = "E:System.Collections.ObjectModel.ObservableCollection`1.CollectionChanged" /> event with the provided arguments.
         /// </summary>
         /// <param name = "e">Arguments of the event being raised.</param>
-        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e) {
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
             base.OnCollectionChanged(e);
 
             if (e.OldItems != null)

--- a/src/Caliburn.Micro.Platform/Platforms/Maui/AttachedCollection.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/AttachedCollection.cs
@@ -46,9 +46,9 @@
         /// <param name="item">The item that was added.</param>
         protected virtual void OnItemAdded(BindableObject item)
         {
-            if (associatedObject != null && item is IAttachedObject)
+            if (associatedObject != null && item is IAttachedObject attached)
             {
-                ((IAttachedObject)item).Attach(associatedObject);
+                attached.Attach(associatedObject);
             }
         }
 
@@ -58,10 +58,10 @@
         /// <param name="item">The item that was removed.</param>
         protected virtual void OnItemRemoved(BindableObject item)
         {
-            if (item is IAttachedObject &&
-                ((IAttachedObject)item).AssociatedObject != null)
+            if (item is IAttachedObject attached &&
+                attached.AssociatedObject != null)
             {
-                ((IAttachedObject)item).Detach();
+                attached.Detach();
             }
         }
 

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
@@ -1,6 +1,5 @@
 ﻿namespace Caliburn.Micro.Xamarin.Forms
 {
-    using System;
     using System.Collections.Specialized;
     using System.Linq;
     using global::Xamarin.Forms;
@@ -10,7 +9,7 @@
     /// </summary>
     /// <typeparam name="T">The type of item in the attached collection.</typeparam>
     public class AttachedCollection<T> : BindableCollection<BindableObject>, IAttachedObject
-        where T : BindableObject, IAttachedObject 
+        where T : BindableObject, IAttachedObject
     {
         private BindableObject associatedObject;
 
@@ -27,7 +26,8 @@
         /// <summary>
         /// Detaches the collection.
         /// </summary>
-        public void Detach() {
+        public void Detach()
+        {
             this.OfType<IAttachedObject>().Apply(x => x.Detach());
             associatedObject = null;
         }
@@ -35,7 +35,8 @@
         /// <summary>
         /// The currently attached object.
         /// </summary>
-        public BindableObject AssociatedObject {
+        public BindableObject AssociatedObject
+        {
             get { return associatedObject; }
         }
 
@@ -43,10 +44,11 @@
         /// Called when an item is added from the collection.
         /// </summary>
         /// <param name="item">The item that was added.</param>
-        protected virtual void OnItemAdded(BindableObject item) {
-            if (associatedObject != null) {
-                if (item is IAttachedObject)
-                    ((IAttachedObject) item).Attach(associatedObject);
+        protected virtual void OnItemAdded(BindableObject item)
+        {
+            if (associatedObject != null && item is IAttachedObject)
+            {
+                ((IAttachedObject)item).Attach(associatedObject);
             }
         }
 
@@ -54,9 +56,11 @@
         /// Called when an item is removed from the collection.
         /// </summary>
         /// <param name="item">The item that was removed.</param>
-        protected virtual void OnItemRemoved(BindableObject item) {
-            if (item is IAttachedObject && ((IAttachedObject) item).AssociatedObject != null) {
-                ((IAttachedObject) item).Detach();
+        protected virtual void OnItemRemoved(BindableObject item)
+        {
+            if (item is IAttachedObject && ((IAttachedObject)item).AssociatedObject != null)
+            {
+                ((IAttachedObject)item).Detach();
             }
         }
 
@@ -64,7 +68,8 @@
         /// Raises the <see cref = "E:System.Collections.ObjectModel.ObservableCollection`1.CollectionChanged" /> event with the provided arguments.
         /// </summary>
         /// <param name = "e">Arguments of the event being raised.</param>
-        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e) {
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
             base.OnCollectionChanged(e);
 
             if (e.OldItems != null)

--- a/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs
@@ -46,9 +46,9 @@
         /// <param name="item">The item that was added.</param>
         protected virtual void OnItemAdded(BindableObject item)
         {
-            if (associatedObject != null && item is IAttachedObject)
+            if (associatedObject != null && item is IAttachedObject attached)
             {
-                ((IAttachedObject)item).Attach(associatedObject);
+                attached.Attach(associatedObject);
             }
         }
 
@@ -58,9 +58,9 @@
         /// <param name="item">The item that was removed.</param>
         protected virtual void OnItemRemoved(BindableObject item)
         {
-            if (item is IAttachedObject && ((IAttachedObject)item).AssociatedObject != null)
+            if (item is IAttachedObject attached && attached.AssociatedObject != null)
             {
-                ((IAttachedObject)item).Detach();
+                attached.Detach();
             }
         }
 


### PR DESCRIPTION

This pull request introduces code style improvements and logic simplifications in the `AttachedCollection` classes for both the Maui and Xamarin.Forms platforms. The changes enhance readability and maintain consistency across the codebase.

### Code Style Improvements:
* Updated method formatting in `src/Caliburn.Micro.Platform/Platforms/Maui/AttachedCollection.cs` to use consistent brace placement and simplify conditional logic in methods like `Detach`, `OnItemAdded`, `OnItemRemoved`, and `OnCollectionChanged`. [[1]](diffhunk://#diff-602ee3456c9b305181016dbd4a6f1248e739c02ab1e076e9abf0cbf943581823L30-R50) [[2]](diffhunk://#diff-602ee3456c9b305181016dbd4a6f1248e739c02ab1e076e9abf0cbf943581823L57-R63) [[3]](diffhunk://#diff-602ee3456c9b305181016dbd4a6f1248e739c02ab1e076e9abf0cbf943581823L68-R73)
* Applied the same formatting and logic updates to `src/Caliburn.Micro.Platform/Platforms/Xamarin.Forms/AttachedCollection.cs`, ensuring consistency with the Maui implementation. [[1]](diffhunk://#diff-625de7f8560e970982b86cb366acda01c853fe7ab0320717559d427c3468bb4aL30-R50) [[2]](diffhunk://#diff-625de7f8560e970982b86cb366acda01c853fe7ab0320717559d427c3468bb4aL57-R62) [[3]](diffhunk://#diff-625de7f8560e970982b86cb366acda01c853fe7ab0320717559d427c3468bb4aL67-R72)

### Unused Code Removal:
* Removed unused `using System;` directives from both `AttachedCollection` files to clean up unnecessary imports. [[1]](diffhunk://#diff-602ee3456c9b305181016dbd4a6f1248e739c02ab1e076e9abf0cbf943581823L3) [[2]](diffhunk://#diff-625de7f8560e970982b86cb366acda01c853fe7ab0320717559d427c3468bb4aL3)