### PR TITLE
Update WindowManager.cs

### DIFF
--- a/src/Caliburn.Micro.Platform/Platforms/netcore-avalonia/WindowManager.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/netcore-avalonia/WindowManager.cs
@@ -137,11 +137,11 @@ namespace Caliburn.Micro
             var view = EnsureWindow(rootModel, view1);
 
             var haveDisplayName = rootModel as IHaveDisplayName;
-            if (string.IsNullOrEmpty(view.Title) && haveDisplayName != null && !ConventionManager.HasBinding(view, Window.TitleProperty))
+            if ((string.IsNullOrEmpty(view.Title) || view.Title == "Window") && haveDisplayName != null && !ConventionManager.HasBinding(view, Window.TitleProperty))
             {
                 var binding = new Binding("DisplayName") { Mode = BindingMode.TwoWay };
                 view.Bind(Window.TitleProperty, binding);
-            }
+            }            
 
             ApplySettings(view, settings);
             var conductor = new WindowConductor(rootModel, view);


### PR DESCRIPTION
This pull request updates the logic for setting the title of a window in the `CreateWindowAsync` method to handle a specific edge case. The change ensures that windows with a default title of "Window" are treated as if they have no title and are updated accordingly.

### Enhancements to window title handling:
* [`src/Caliburn.Micro.Platform/Platforms/netcore-avalonia/WindowManager.cs`](diffhunk://#diff-cb9fc9540a877be057da1b0e2d493e8c12c6222b80b97ae9e282e3fe4f2f2527L140-R140): Modified the condition in the `CreateWindowAsync` method to check if the window's title is either empty or set to the default value "Window" before applying a binding to the `DisplayName` property. This ensures better handling of default window titles.