### PR TITLE
1001 allow avalonia and maui to have different versions

### DIFF
--- a/src/Caliburn.Micro.Avalonia/version.json
+++ b/src/Caliburn.Micro.Avalonia/version.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "5.0-beta",
+    "nugetPackageVersion": {
+        "semVer": 2
+    },
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$"
+    ],
+    "cloudBuild": {
+        "buildNumber": {
+            "enabled": true,
+            "includeCommitId": {
+                "when": "nonPublicReleaseOnly",
+                "where": "buildMetadata"
+            }
+        },
+    "setVersionVariables": true
+    }
+}

--- a/src/Caliburn.Micro.Maui/version.json
+++ b/src/Caliburn.Micro.Maui/version.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "5.0-beta",
+    "nugetPackageVersion": {
+        "semVer": 2
+    },
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$"
+    ],
+    "cloudBuild": {
+        "buildNumber": {
+            "enabled": true,
+            "includeCommitId": {
+                "when": "nonPublicReleaseOnly",
+                "where": "buildMetadata"
+            }
+        },
+    "setVersionVariables": true
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "5.0-beta",
+    "version": "5.0",
     "nugetPackageVersion": {
         "semVer": 2
     },


### PR DESCRIPTION
This pull request updates versioning information across the project, preparing for a stable 5.0 release and introducing version tracking for new components.

Versioning updates:

* Updated the root `version.json` to set the version from `"5.0-beta"` to the stable `"5.0"`, indicating readiness for a public release.

New version tracking for components:

* Added a new `version.json` to `src/Caliburn.Micro.Avalonia`, establishing independent versioning for this component and setting its version to `"5.0-beta"`.
* Added a new `version.json` to `src/Caliburn.Micro.Maui`, establishing independent versioning for this component and setting its version to `"5.0-beta"`.