### PR TITLE
Add unit tests for EventAggregator thread behavior

### DIFF
--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -73,7 +73,10 @@ namespace Caliburn.Micro.Core.Tests
             var mockTargets = new Mock<IHandle<object>>[20];
             for (int i = 0; i < mockTargets.Length; i++)
             {
-                mockTargets[i] = new Mock<IHandle<object>>();
+            var mockTargets = new Mock<IHandle<string>>[20];
+            for (int i = 0; i < mockTargets.Length; i++)
+            {
+                mockTargets[i] = new Mock<IHandle<string>>();
                 eventAggregator.SubscribeOnPublishedThread(mockTargets[i].Object);
             }
 

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -7,10 +7,7 @@ namespace Caliburn.Micro.Core.Tests
 {
     public class EventAggregatorExtensionsTests
     {
-
-
-
-
+        const int NumberOfMockTargets = 20;
         [Fact]
         public void SubscribeOnUIThread_CallsSubscribeWithUIThreadMarshaller()
         {
@@ -24,9 +21,9 @@ namespace Caliburn.Micro.Core.Tests
             mockAggregator.Object.SubscribeOnUIThread(subscriber);
 
             Assert.NotNull(capturedMarshaller);
-            // UI thread marshaller returns a Task
-            var tcs = new TaskCompletionSource<bool>();
-            var task = capturedMarshaller(() => { tcs.SetResult(true); return tcs.Task; });
+            // UI thread marshaler returns a Task
+            var taskSource = new TaskCompletionSource<bool>();
+            var task = capturedMarshaller(() => { taskSource.SetResult(true); return taskSource.Task; });
             Assert.IsAssignableFrom<Task>(task);
         }
 
@@ -35,15 +32,18 @@ namespace Caliburn.Micro.Core.Tests
         {
             var eventAggregator = new EventAggregator();
             string message = "Test";
-            var cancellationToken = new CancellationTokenSource().Token;
-            var mockTarget1 = new Mock<IHandle<string>>();
-            var mockTarget2 = new Mock<IHandle<string>>();
-            eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
-            eventAggregator.SubscribeOnPublishedThread(mockTarget2.Object);
-            await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var cancellationToken = tokenSource.Token;
+                var mockTarget1 = new Mock<IHandle<string>>();
+                var mockTarget2 = new Mock<IHandle<string>>();
+                eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
+                eventAggregator.SubscribeOnPublishedThread(mockTarget2.Object);
+                await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
 
-            mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
-            mockTarget2.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+                mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+                mockTarget2.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+            }
         }
 
 
@@ -52,14 +52,17 @@ namespace Caliburn.Micro.Core.Tests
         {
             var eventAggregator = new EventAggregator();
             var message = new object();
-            var cancellationToken = new CancellationTokenSource().Token;
-            var mockTarget1 = new Mock<IHandle<object>>();
-            eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var cancellationToken = tokenSource.Token;
+                var mockTarget1 = new Mock<IHandle<object>>();
+                eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
 
 
-            await eventAggregator.PublishOnBackgroundThreadAsync(message, cancellationToken);
+                await eventAggregator.PublishOnBackgroundThreadAsync(message, cancellationToken);
 
-            mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+                mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+            }
         }
 
         [Fact]
@@ -67,25 +70,25 @@ namespace Caliburn.Micro.Core.Tests
         {
             var eventAggregator = new EventAggregator();
             string message = "Test";
-            var cancellationToken = new CancellationTokenSource().Token;
-
-            // Create 20 mock targets
-            var mockTargets = new Mock<IHandle<object>>[20];
-            for (int i = 0; i < mockTargets.Length; i++)
+            using (var tokenSource = new CancellationTokenSource())
             {
-            var mockTargets = new Mock<IHandle<string>>[20];
-            for (int i = 0; i < mockTargets.Length; i++)
-            {
-                mockTargets[i] = new Mock<IHandle<string>>();
-                eventAggregator.SubscribeOnPublishedThread(mockTargets[i].Object);
-            }
+                var cancellationToken = tokenSource.Token;
 
-            await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
+                // Create 20 mock targets
+                var mockTargets = new Mock<IHandle<string>>[NumberOfMockTargets];
+                for (int i = 0; i < mockTargets.Length; i++)
+                {
+                    mockTargets[i] = new Mock<IHandle<string>>();
+                    eventAggregator.SubscribeOnPublishedThread(mockTargets[i].Object);
+                }
 
-            // Verify HandleAsync was called on each
-            foreach (var mockTarget in mockTargets)
-            {
-                mockTarget.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+                await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
+
+                // Verify HandleAsync was called on each
+                foreach (var mockTarget in mockTargets)
+                {
+                    mockTarget.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+                }
             }
         }
     }

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -11,7 +11,6 @@ namespace Caliburn.Micro.Core.Tests
 
 
 
-
         [Fact]
         public void SubscribeOnUIThread_CallsSubscribeWithUIThreadMarshaller()
         {

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -63,7 +63,6 @@ namespace Caliburn.Micro.Core.Tests
             mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
         }
 
-
         [Fact]
         public async Task PublishOnCurrentThreadAsync_CallsHandleAsyncOnAllSubscribedTargets()
         {

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -48,7 +48,6 @@ namespace Caliburn.Micro.Core.Tests
         }
 
 
-
         [Fact]
         public async Task PublishOnBackgroundThreadAsync_CallsPublishAsyncWithBackgroundMarshaller()
         {

--- a/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
+++ b/src/Caliburn.Micro.Core.Tests/EventAggregatorExtensionsTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+namespace Caliburn.Micro.Core.Tests
+{
+    public class EventAggregatorExtensionsTests
+    {
+
+
+
+
+
+        [Fact]
+        public void SubscribeOnUIThread_CallsSubscribeWithUIThreadMarshaller()
+        {
+            var mockAggregator = new Mock<IEventAggregator>();
+            var subscriber = new object();
+
+            Func<Func<Task>, Task> capturedMarshaller = null;
+            mockAggregator.Setup(x => x.Subscribe(subscriber, It.IsAny<Func<Func<Task>, Task>>()))
+                .Callback<object, Func<Func<Task>, Task>>((_, m) => capturedMarshaller = m);
+
+            mockAggregator.Object.SubscribeOnUIThread(subscriber);
+
+            Assert.NotNull(capturedMarshaller);
+            // UI thread marshaller returns a Task
+            var tcs = new TaskCompletionSource<bool>();
+            var task = capturedMarshaller(() => { tcs.SetResult(true); return tcs.Task; });
+            Assert.IsAssignableFrom<Task>(task);
+        }
+
+        [Fact]
+        public async Task PublishOnCurrentThreadAsync_CallsPublishAsyncWithDirectMarshaller()
+        {
+            var eventAggregator = new EventAggregator();
+            string message = "Test";
+            var cancellationToken = new CancellationTokenSource().Token;
+            var mockTarget1 = new Mock<IHandle<string>>();
+            var mockTarget2 = new Mock<IHandle<string>>();
+            eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
+            eventAggregator.SubscribeOnPublishedThread(mockTarget2.Object);
+            await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
+
+            mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+            mockTarget2.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+        }
+
+
+
+        [Fact]
+        public async Task PublishOnBackgroundThreadAsync_CallsPublishAsyncWithBackgroundMarshaller()
+        {
+            var eventAggregator = new EventAggregator();
+            var message = new object();
+            var cancellationToken = new CancellationTokenSource().Token;
+            var mockTarget1 = new Mock<IHandle<object>>();
+            eventAggregator.SubscribeOnPublishedThread(mockTarget1.Object);
+
+
+            await eventAggregator.PublishOnBackgroundThreadAsync(message, cancellationToken);
+
+            mockTarget1.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+        }
+
+
+        [Fact]
+        public async Task PublishOnCurrentThreadAsync_CallsHandleAsyncOnAllSubscribedTargets()
+        {
+            var eventAggregator = new EventAggregator();
+            string message = "Test";
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            // Create 20 mock targets
+            var mockTargets = new Mock<IHandle<object>>[20];
+            for (int i = 0; i < mockTargets.Length; i++)
+            {
+                mockTargets[i] = new Mock<IHandle<object>>();
+                eventAggregator.SubscribeOnPublishedThread(mockTargets[i].Object);
+            }
+
+            await eventAggregator.PublishOnCurrentThreadAsync(message, cancellationToken);
+
+            // Verify HandleAsync was called on each
+            foreach (var mockTarget in mockTargets)
+            {
+                mockTarget.Verify(x => x.HandleAsync(message, cancellationToken), Times.Once);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented tests in `EventAggregatorExtensionsTests` to verify the correct behavior of the `EventAggregator` when subscribing and publishing messages across different threads. The tests ensure that the appropriate marshaller is invoked for UI thread subscriptions and confirm that messages are published correctly on both current and background threads. Additionally, a test was added to validate that all subscribed targets handle the published message on the current thread.

Issue #993 