### PR TITLE
Update Avalonia packages to version 11.3.5

### DIFF
--- a/samples/features/Features.Avalonia/Features.Avalonia.csproj
+++ b/samples/features/Features.Avalonia/Features.Avalonia.csproj
@@ -17,18 +17,18 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.2.3" />
+    <PackageReference Include="Avalonia" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.5" />
 
-    <PackageReference Include="Avalonia.Themes.FLuent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.0.7" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.7" />
+    <PackageReference Include="Avalonia.Themes.FLuent" Version="11.3.5" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.5" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Caliburn.Micro.Avalonia">

--- a/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
+++ b/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
@@ -16,6 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -43,12 +45,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.0" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0" />
+    <PackageReference Include="Avalonia" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.5" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <ProjectReference Include="..\Caliburn.Micro.Avalonia\Caliburn.Micro.Avalonia.csproj" />
     <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -22,13 +22,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'" />
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.2.2" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.0" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0" />
+    <PackageReference Include="Avalonia" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.5" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.5" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
     <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />
     <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Updated project files for `Features.Avalonia`, `Caliburn.Micro.Avalonia.Tests`, and `Caliburn.Micro.Avalonia` to reference newer versions of Avalonia packages. Changed versions for `Avalonia`, `Avalonia.Desktop`, `Avalonia.Markup.Xaml.Loader`, `Avalonia.Themes.FLuent`, and `Avalonia.Diagnostics` from `11.2.x` to `11.3.5`. Added new package references for `Xaml.Behaviors.Avalonia` and `Xaml.Behaviors.Interactivity` at version `11.3.2` to leverage new features and improvements.