### PR TITLE
Removed Microsoft.Maui.Controls.Maui.Compatbility is not needed and deprecated

### DIFF
--- a/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
+++ b/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
@@ -17,7 +17,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.92" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.92" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
+++ b/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
@@ -110,7 +110,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.92" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.92" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed Microsoft.Maui.Controls.Maui.Compatbility is not needed and deprecated

Was once used for Xamarin.Forms compatibility But now must types there are obsolete