### PR TITLE
update Avalonia ui csproj for nuget

### DIFF
--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0" PrivateAssets="all">
+    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <IncludeAssets>Caliburn.Micro.Platform.Core.dll</IncludeAssets>
     </ProjectReference>

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -29,10 +29,18 @@
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
-    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />
-    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0" PrivateAssets="all">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+      <IncludeAssets>Caliburn.Micro.Platform.Core.dll</IncludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+      <ExcludeAssets>Caliburn.Micro.Core.dll</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Caliburn.Micro.Platform\*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\netcore-avalonia\AssemblyInfo.cs" Link="Platforms\netcore-avalonia\AssemblyInfo.cs" />


### PR DESCRIPTION
This pull request updates how project references are handled in the `Caliburn.Micro.Avalonia.csproj` file to improve compatibility and asset management for the referenced projects. The main changes involve specifying additional properties for project references and controlling which assets are included or excluded.

Project reference configuration improvements:

* Added an explicit `ItemGroup` for `Caliburn.Micro.Platform.Core` and `Caliburn.Micro.Core` project references, specifying `TargetFramework=netstandard2.0`, controlling asset inclusion/exclusion, and setting `ReferenceOutputAssembly` to true for both. (`src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj`, [src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csprojL32-R43](diffhunk://#diff-e3fbfc36d57f1c4655bfae32dfcc61544655870f5c06f05396572ec0ff96cec5L32-R43))
* Removed the previous, simpler project references for `Caliburn.Micro.Core` and `Caliburn.Micro.Platform.Core`, replacing them with the more detailed configuration above. (`src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj`, [src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csprojL32-R43](diffhunk://#diff-e3fbfc36d57f1c4655bfae32dfcc61544655870f5c06f05396572ec0ff96cec5L32-R43))