### PR TITLE
Update project references in Caliburn.Micro.Avalonia

### DIFF
--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -32,11 +32,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0">
+    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" PrivateAssets="all">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <IncludeAssets>Caliburn.Micro.Platform.Core.dll</IncludeAssets>
     </ProjectReference>
-    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.0">
+    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" >
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <ExcludeAssets>Caliburn.Micro.Core.dll</ExcludeAssets>
     </ProjectReference>


### PR DESCRIPTION
Modified `Caliburn.Micro.Avalonia.csproj` to remove `AdditionalProperties` from `ProjectReference` elements for `Caliburn.Micro.Platform.Core` and `Caliburn.Micro.Core`. Added `PrivateAssets="all"` for `Caliburn.Micro.Platform.Core` and `ExcludeAssets` for `Caliburn.Micro.Core` to better manage dependencies and control assembly inclusion in the build output.