### PR TITLE
Fix NullReferenceException in ActionMessage when EnableGuardDuringInvocation is enabled

### DIFF
--- a/src/Caliburn.Micro.Platform/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/ActionMessage.cs
@@ -416,7 +416,7 @@
 
             _context.EventArgs = eventArgs;
 
-            if (EnforceGuardsDuringInvocation && (_context?.CanExecute() != true))
+            if (EnforceGuardsDuringInvocation && _context.CanExecute != null && !_context.CanExecute())
             {
                 return;
             }


### PR DESCRIPTION
The invocation of an ActionMessage results in a NullReferenceException when used in a WPF application if EnableGuardDuringInvocation is set to true and no guard exists.

It looks like someone tried to optimize the null check by using the ? syntax, but in fact the _context was checked against null instead of the Func<bool> CanExecute.

Old: 
.. .&& !_context?.CanExecute()

New:
            if (EnforceGuardsDuringInvocation && _context.CanExecute != null && !_context.CanExecute())
            {
                return;
            }

The issue affects WPF applications, not Maui (different ActionMessage implementation). So I aligned the implementation to match the (correct) Maui implementation.

Without this fix we are not able to update to Caliburn.Micro 5.