### PR TITLE
Potential fix for code scanning alert no. 79: Missed opportunity to use Select

### DIFF
--- a/src/Caliburn.Micro.Core/BindableCollection.cs
+++ b/src/Caliburn.Micro.Core/BindableCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-
+using System.Linq;
 namespace Caliburn.Micro
 {
     /// <summary>
@@ -250,9 +250,8 @@ namespace Caliburn.Micro
             {
                 var previousNotificationSetting = IsNotifying;
                 IsNotifying = false;
-                foreach (var item in items)
+                foreach (var index in items.Select(item => IndexOf(item)))
                 {
-                    var index = IndexOf(item);
                     if (index >= 0)
                     {
                         RemoveItemBase(index);


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/79](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/79)

To fix the problem, rewrite the `foreach (var item in items)` loop inside the `RemoveRange` local function (lines 253-260 in `RemoveRange(IEnumerable<T> items)`) to iterate directly over the indexes generated from the items using LINQ's `.Select(item => IndexOf(item))`. For each index, perform the conditional check and potential removal as before. This is accomplished by changing the loop to `foreach (var index in items.Select(item => IndexOf(item)))`. Ensure that System.Linq is imported (if not already present) for `.Select` to function.

Edit only the affected method in `src/Caliburn.Micro.Core/BindableCollection.cs`, specifically lines 253-260 within `RemoveRange()`. No new method definitions are required. Double-check that `using System.Linq;` is imported at the top of the file (in the provided lines, it is not), so add it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
