### PR TITLE
Add missing null checks to Bind

### DIFF
--- a/src/Caliburn.Micro.Platform/Bind.cs
+++ b/src/Caliburn.Micro.Platform/Bind.cs
@@ -134,7 +134,7 @@ namespace Caliburn.Micro
 
         static void ModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (View.InDesignMode || object.ReferenceEquals(e.NewValue, e.OldValue))
+            if (View.InDesignMode || e.NewValue == null || object.ReferenceEquals(e.NewValue, e.OldValue))
             {
                 return;
             }
@@ -165,7 +165,7 @@ namespace Caliburn.Micro
 
         static void ModelWithoutContextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (View.InDesignMode || object.ReferenceEquals(e.NewValue, e.OldValue))
+            if (View.InDesignMode || e.NewValue == null || object.ReferenceEquals(e.NewValue, e.OldValue))
             {
                 return;
             }


### PR DESCRIPTION
When updating our application to version 5, we began getting a `NullReferenceException` that did not occur previously.

When Bind.Model is bound to null, a `NullReferenceException` will be thrown here:
https://github.com/Caliburn-Micro/Caliburn.Micro/blob/6a440a40dd03e2e38a44be91c5d90c8d7896e3f8/src/Caliburn.Micro.Platform/ViewModelBinder.cs#L270

Previously, there were null checks that prevented it reaching that line of code. But, they were removed in this commit:
https://github.com/Caliburn-Micro/Caliburn.Micro/commit/e6df13a06b6a5754661a53dd60ded29720b4cf10

This pull request simply restores the null checks.