### PR TITLE
Update dependencies, SDKs, and target frameworks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,8 +55,11 @@ jobs:
         # You may pin to the exact commit or the version.
         # uses: NuGet/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37
       uses: NuGet/setup-nuget@v2
-    - name: Add msbuild to PATH
+    # Setup MSBuild with VS2026
+    - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
+      with:
+        vs-version: '17.6' # VS2026 internal version
       
     - name: search workloads
       run: dotnet workload search

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         config-file: ./.github/codeql/codeql-config.yml  # <-- add this line
         languages: csharp
@@ -40,12 +40,12 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: src/global.json
       
     - name: Setup Java SDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'microsoft' 
         java-version: 17
@@ -54,10 +54,10 @@ jobs:
     - name: Setup NuGet.exe for use with actions
         # You may pin to the exact commit or the version.
         # uses: NuGet/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v4
     # Setup MSBuild with VS2026
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
       with:
         vs-version: '17.6' # VS2026 internal version
       
@@ -86,4 +86,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v3
       with:
-        vs-version: '17.6' # VS2026 internal version
+        vs-version: '18.0' # VS2026 version
       
     - name: search workloads
       run: dotnet workload search

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyse:
     name: Analyse
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
         # required for all workflows
         security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyse:
     name: Analyse
-    runs-on: windows-2022
+    runs-on: windows-2025
     permissions:
         # required for all workflows
         security-events: write

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,9 +42,11 @@ jobs:
         # You may pin to the exact commit or the version.
         # uses: NuGet/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37
       uses: NuGet/setup-nuget@v2
-    - name: Add msbuild to PATH
+    # Setup MSBuild with VS2026
+    - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
-      
+      with:
+        vs-version: '17.6' # VS2026 internal version
     - name: search workloads
       run: dotnet workload search
     - name: restore workloads

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on:  windows-2025-vs2026
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: src/global.json
     - name: Setup Java SDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'microsoft' 
         java-version: 17
@@ -41,10 +41,10 @@ jobs:
     - name: Setup NuGet.exe for use with actions
         # You may pin to the exact commit or the version.
         # uses: NuGet/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v4
     # Setup MSBuild with VS2026
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
       with:
         vs-version: '17.6' # VS2026 internal version
     - name: search workloads

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
 
-    runs-on:  windows-2025
+    runs-on:  windows-2025-vs2026
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
 
-    runs-on:  windows-2022
+    runs-on:  windows-2025
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on:  windows-2025-vs2026
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work
     - name: Setup .NET

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -15,7 +15,7 @@ steps:
   displayName: 'Install .NET'
   inputs:
     packageType: 'sdk'
-    version: '9.0.x' 
+    version: '10.0.x' 
 
 
 - task: PowerShell@2

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: windows-2022
+  vmImage: windows-2025-vs2026
   demands:
   - MSBuild
 

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -30,7 +30,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Install Nuget'
   inputs:
-    versionSpec: '6.12.1'
+    versionSpec: '7.6.0'
 
 - task: DotNetCoreCLI@2  
   inputs:

--- a/samples/features/Features.UWP/Features.UWP.csproj
+++ b/samples/features/Features.UWP/Features.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Features.CrossPlatform</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/samples/features/Features.sln
+++ b/samples/features/Features.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11806.211 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Features.CrossPlatform.Shared", "Features.CrossPlatform.Shared\Features.CrossPlatform.Shared.shproj", "{7BDAB9D6-294B-4AA5-A7F5-3B2992E1D5D2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Features.UWP", "Features.UWP\Features.UWP.csproj", "{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Features.WPF", "Features.WPF\Features.WPF.csproj", "{3BAE54C3-20A6-40A8-93BE-B324FED7D3FC}"
 EndProject
@@ -49,82 +47,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|Any CPU.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|Any CPU.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|Any CPU.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|ARM.ActiveCfg = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|ARM.Build.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|ARM.Deploy.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|arm64.ActiveCfg = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|arm64.Build.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|arm64.Deploy.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhone.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhone.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhone.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|iPhoneSimulator.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x64.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x64.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x64.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x86.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x86.Build.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Ad-Hoc|x86.Deploy.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|Any CPU.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|Any CPU.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|Any CPU.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|ARM.ActiveCfg = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|ARM.Build.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|ARM.Deploy.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|arm64.ActiveCfg = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|arm64.Build.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|arm64.Deploy.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhone.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhone.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhone.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhoneSimulator.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhoneSimulator.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|iPhoneSimulator.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x64.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x64.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x64.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x86.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x86.Build.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.AppStore|x86.Deploy.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|Any CPU.Build.0 = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|Any CPU.Deploy.0 = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|ARM.ActiveCfg = Debug|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|ARM.Build.0 = Debug|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|ARM.Deploy.0 = Debug|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|arm64.ActiveCfg = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|arm64.Build.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|arm64.Deploy.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|iPhone.ActiveCfg = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|iPhoneSimulator.ActiveCfg = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x64.ActiveCfg = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x64.Build.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x64.Deploy.0 = Debug|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x86.ActiveCfg = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x86.Build.0 = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Debug|x86.Deploy.0 = Debug|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|Any CPU.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|Any CPU.Build.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|Any CPU.Deploy.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|ARM.ActiveCfg = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|ARM.Build.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|ARM.Deploy.0 = Release|ARM
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|arm64.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|arm64.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|arm64.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|iPhone.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|iPhoneSimulator.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x64.ActiveCfg = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x64.Build.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x64.Deploy.0 = Release|x64
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x86.ActiveCfg = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x86.Build.0 = Release|x86
-		{FFAC51BE-42E4-4BD3-96AA-96FE2A7853AC}.Release|x86.Deploy.0 = Release|x86
 		{3BAE54C3-20A6-40A8-93BE-B324FED7D3FC}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{3BAE54C3-20A6-40A8-93BE-B324FED7D3FC}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{3BAE54C3-20A6-40A8-93BE-B324FED7D3FC}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -392,6 +314,5 @@ Global
 		Features.Forms\Features.Forms\Features.Forms.projitems*{aed0f189-e321-4d50-b4dc-36023d91ba0a}*SharedItemsImports = 13
 		Features.CrossPlatform.Shared\Features.CrossPlatform.Shared.projitems*{c2dec486-7fd6-4a37-8a49-c31d4993f180}*SharedItemsImports = 5
 		Features.CrossPlatform.Shared\Features.CrossPlatform.Shared.projitems*{e080007b-0470-4fbe-a01c-79aead3f9dbe}*SharedItemsImports = 5
-		Features.CrossPlatform.Shared\Features.CrossPlatform.Shared.projitems*{ffac51be-42e4-4bd3-96aa-96fe2a7853ac}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
+++ b/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
@@ -15,11 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -28,7 +27,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
+    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -41,7 +41,7 @@
 
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.5" />
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.5" />
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.5" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />
@@ -45,7 +46,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" PrivateAssets="all">
     </ProjectReference>
-    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" >
+    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj">
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -76,26 +77,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
-  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage"
-        Condition="'@(ProjectReference)' != '' and @(ProjectReference->AnyHaveMetadataValue('PrivateAssets', 'all'))"
-        DependsOnTargets="BuildOnlySettings;ResolveReferences">
+  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage" Condition="'@(ProjectReference)' != '' and @(ProjectReference-&gt;AnyHaveMetadataValue('PrivateAssets', 'all'))" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all'))" />
+      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'all'))" />
 
-      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)"
-                            TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))"
-                                   TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)"
-                                   TargetFramework="$(TargetFramework)"
-                                   Condition="'$(IncludeSymbols)' == 'true'" />
+      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" TargetFramework="$(TargetFramework)" Condition="'$(IncludeSymbols)' == 'true'" />
 
       <!-- Remove symbol from the non symbol package. -->
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))" />
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.xml'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.xml'))" />
     </ItemGroup>
   </Target>
 

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.5" />
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.5" />
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.5" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.2" />

--- a/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
+++ b/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,13 +14,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
+++ b/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
@@ -34,8 +34,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
+++ b/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseMaui>true</UseMaui>
@@ -16,14 +16,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
+++ b/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 
     <UseMaui>true</UseMaui>
@@ -10,9 +10,9 @@
 
     <DefineConstants>MAUI</DefineConstants>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 
@@ -86,17 +86,17 @@
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\Android\**\*.cs" Link="Platforms\Maui\Android\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\ios\**\*.cs" Link="Platforms\Maui\ios\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\ios\**\*.cs" Link="Platforms\Maui\ios\**\*.cs" />
   </ItemGroup>
@@ -118,7 +118,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,29 +129,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
   <!-- Add ProjectReferences output which are flagged as PrivateAssets="all" into the package. -->
-  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage"
-          Condition="'@(ProjectReference)' != '' and @(ProjectReference->AnyHaveMetadataValue('PrivateAssets', 'all'))"
-          DependsOnTargets="BuildOnlySettings;ResolveReferences">
+  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage" Condition="'@(ProjectReference)' != '' and @(ProjectReference-&gt;AnyHaveMetadataValue('PrivateAssets', 'all'))" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all'))" />
+      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'all'))" />
 
-      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)"
-                            TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))"
-                                   TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)"
-                                   TargetFramework="$(TargetFramework)"
-                                   Condition="'$(IncludeSymbols)' == 'true'" />
+      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" TargetFramework="$(TargetFramework)" Condition="'$(IncludeSymbols)' == 'true'" />
 
       <!-- Remove symbol from the non symbol package. -->
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))" />
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.xml'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.xml'))" />
     </ItemGroup>
   </Target>
   

--- a/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
+++ b/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
+++ b/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -14,15 +14,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
+++ b/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;uap10.0.19041;net9.0-android;net9.0-ios;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net9.0-android;net9.0-ios;net8.0-windows;net9.0-windows;</TargetFrameworks>
     <PackageId>Caliburn.Micro</PackageId>
     <Product>Caliburn.Micro</Product>
     <RootNamespace>Caliburn.Micro</RootNamespace>
@@ -60,14 +60,13 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Include="Platforms\uap\Caliburn.Micro.Platform.rd.xml" PackagePath="lib\uap10.0.19041\Caliburn.Micro.Platform\Properties\Caliburn.Micro.Platform.rd.xml" Pack="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.19041'">
+  <!--<ItemGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <Compile Include="Platforms\uap\**\*.cs" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
-  </ItemGroup>
+  </ItemGroup>-->
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
     <Compile Remove="*.cs" />
@@ -82,12 +81,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Platforms\WinUI3\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -89,9 +89,4 @@
     <Folder Include="Platforms\WinUI3\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
-  </ItemGroup>
-
 </Project>

--- a/src/Caliburn.Micro.Platform/Parser.cs
+++ b/src/Caliburn.Micro.Platform/Parser.cs
@@ -91,7 +91,7 @@ namespace Caliburn.Micro
 #else
             if (string.IsNullOrEmpty(text))
             {
-                return new TriggerBase[0];
+                return Array.Empty<TriggerBase>();
             }
             var triggers = new List<TriggerBase>();
 #endif

--- a/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
+++ b/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
@@ -41,7 +41,7 @@
 
     </ItemGroup>
 
-  <ItemGroup >
+  <ItemGroup>
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\uap\**\*.cs" />
   </ItemGroup>
@@ -64,9 +64,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.220902.1-preview1" />
-      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
 
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 </Project>

--- a/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
@@ -88,8 +88,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.x",
+    "version": "10.0.300",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
- Bump versions for test, build, and source link dependencies
- Update MAUI projects to net10.0 and Microsoft.Maui.Controls 10.0.60
- Raise UWP target platform version to 10.0.22621.0
- Switch several projects to Microsoft.NET.Sdk
- Update WinUI3 project to latest WindowsAppSDK and SDK.BuildTools
- Add NETStandard.Library to Avalonia and Platform projects
- Replace xunit and Xunit.StaFact with latest versions and add xunit.v3
- Refactor MSBuild target syntax for compatibility
- Use Array.Empty<TriggerBase>() in Parser.cs for empty triggers
- Comment out unused UWP-specific items in Platform project