### PR TITLE
Potential fix for code scanning alert no. 92: Erroneous class compare

### DIFF
--- a/src/Caliburn.Micro.Platform/ViewModelBinder.cs
+++ b/src/Caliburn.Micro.Platform/ViewModelBinder.cs
@@ -223,7 +223,9 @@ namespace Caliburn.Micro
             // so here we get the actual ViewModel which is in the Instance property of DesignInstanceExtension
             if (View.InDesignMode) {
                 var vmType = viewModel.GetType();
-                if (vmType.FullName == "Microsoft.Expression.DesignModel.InstanceBuilders.DesignInstanceExtension") {
+                var designInstanceExtensionType = Type.GetType("Microsoft.Expression.DesignModel.InstanceBuilders.DesignInstanceExtension, Microsoft.Expression.Interactions", false);
+
+                if (designInstanceExtensionType != null && vmType == designInstanceExtensionType) {
                     var propInfo = vmType.GetProperty("Instance", BindingFlags.Instance | BindingFlags.NonPublic);
                     viewModel = propInfo.GetValue(viewModel, null);
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/92](https://github.com/Caliburn-Micro/Caliburn.Micro/security/code-scanning/92)

Use robust type identity comparison instead of comparing `FullName` strings.

Best fix in this file/region:
- In `src/Caliburn.Micro.Platform/ViewModelBinder.cs`, inside `Bind` where `View.InDesignMode` is handled (around lines 225–229), replace:
  - `if (vmType.FullName == "...DesignInstanceExtension")`
- With:
  - Resolve the known type via `Type.GetType("... , Microsoft.Expression.Interactions")` (assembly-qualified).
  - Compare with `vmType == designInstanceExtensionType`.
  - Keep the existing reflection behavior for `Instance` unchanged.

This preserves functionality while removing the class-name-only compare and making the check explicit and robust.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
