### PR TITLE
.net 10 support, modern uwp, update .net maui version, and update avalonia ui version

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -15,7 +15,7 @@ steps:
   displayName: 'Install .NET'
   inputs:
     packageType: 'sdk'
-    version: '9.0.x' 
+    version: '10.0.x' 
 
 
 - task: PowerShell@2

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: windows-2022
+  vmImage: windows-2025-vs2026
   demands:
   - MSBuild
 

--- a/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
+++ b/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -41,7 +41,7 @@
 
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
+++ b/src/Caliburn.Micro.Avalonia.Tests/Caliburn.Micro.Avalonia.Tests.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
-    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -45,13 +45,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2">
+    <PackageReference Include="Avalonia" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <ProjectReference Include="..\Caliburn.Micro.Avalonia\Caliburn.Micro.Avalonia.csproj" />
     <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -33,16 +33,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'" />
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2">
+    <PackageReference Include="Avalonia" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
-    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.0.1" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
+++ b/src/Caliburn.Micro.Avalonia/Caliburn.Micro.Avalonia.csproj
@@ -79,8 +79,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
   <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage" Condition="'@(ProjectReference)' != '' and @(ProjectReference-&gt;AnyHaveMetadataValue('PrivateAssets', 'all'))" DependsOnTargets="BuildOnlySettings;ResolveReferences">

--- a/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
+++ b/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
+++ b/src/Caliburn.Micro.Core.Tests/Caliburn.Micro.Core.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
+++ b/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
@@ -34,7 +34,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 

--- a/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
+++ b/src/Caliburn.Micro.Core/Caliburn.Micro.Core.csproj
@@ -34,8 +34,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
+++ b/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.80" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
+++ b/src/Caliburn.Micro.Maui.Tests/Caliburn.Micro.Maui.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseMaui>true</UseMaui>
@@ -16,11 +16,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.80" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
+++ b/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 
     <UseMaui>true</UseMaui>
@@ -10,9 +10,9 @@
 
     <DefineConstants>MAUI</DefineConstants>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 
@@ -86,17 +86,17 @@
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\Android\**\*.cs" Link="Platforms\Maui\Android\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\ios\**\*.cs" Link="Platforms\Maui\ios\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\Maui\ios\**\*.cs" Link="Platforms\Maui\ios\**\*.cs" />
   </ItemGroup>
@@ -118,7 +118,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,29 +129,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
   <!-- Add ProjectReferences output which are flagged as PrivateAssets="all" into the package. -->
-  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage"
-          Condition="'@(ProjectReference)' != '' and @(ProjectReference->AnyHaveMetadataValue('PrivateAssets', 'all'))"
-          DependsOnTargets="BuildOnlySettings;ResolveReferences">
+  <Target Name="IncludeProjectReferencesWithPrivateAssetsAttributeInPackage" Condition="'@(ProjectReference)' != '' and @(ProjectReference-&gt;AnyHaveMetadataValue('PrivateAssets', 'all'))" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all'))" />
+      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'all'))" />
 
-      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)"
-                            TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))"
-                                   TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)"
-                                   TargetFramework="$(TargetFramework)"
-                                   Condition="'$(IncludeSymbols)' == 'true'" />
+      <BuildOutputInPackage Include="@(_projectReferenceCopyLocalPaths)" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <TfmSpecificDebugSymbolsFile Include="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" TargetPath="%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" TargetFramework="$(TargetFramework)" Condition="'$(IncludeSymbols)' == 'true'" />
 
       <!-- Remove symbol from the non symbol package. -->
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.pdb'))" />
-      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.xml'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.pdb'))" />
+      <BuildOutputInPackage Remove="@(_projectReferenceCopyLocalPaths-&gt;WithMetadataValue('Extension', '.xml'))" />
     </ItemGroup>
   </Target>
   

--- a/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
+++ b/src/Caliburn.Micro.Maui/Caliburn.Micro.Maui.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Title>Caliburn Micro for .net Maui</Title>
     <PackageIcon>CaliburnIcon.png</PackageIcon>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
@@ -118,7 +118,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.80" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,8 +129,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />

--- a/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
+++ b/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 

--- a/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
+++ b/src/Caliburn.Micro.Platform.Core/Caliburn.Micro.Platform.Core.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
+++ b/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
@@ -14,10 +14,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
+++ b/src/Caliburn.Micro.Platform.Tests/Caliburn.Micro.Platform.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
 </Project>

--- a/src/Caliburn.Micro.Platform/ActionMessage.cs
+++ b/src/Caliburn.Micro.Platform/ActionMessage.cs
@@ -13,7 +13,6 @@
     using Windows.UI.Xaml.Controls;
     using Microsoft.Xaml.Interactivity;
     using TriggerBase = Microsoft.Xaml.Interactivity.IBehavior;
-    using EventTrigger = Microsoft.Xaml.Interactions.Core.EventTriggerBehavior;
 #elif AVALONIA
     using Avalonia;
     using Avalonia.Data;

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -82,8 +82,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
+++ b/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;uap10.0.19041;net9.0-android;net9.0-ios;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net9.0-android;net9.0-ios;net8.0-windows;net9.0-windows</TargetFrameworks>
     <PackageId>Caliburn.Micro</PackageId>
     <Product>Caliburn.Micro</Product>
     <RootNamespace>Caliburn.Micro</RootNamespace>
@@ -38,7 +38,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />
@@ -47,11 +47,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <Compile Include="Platforms\net46-netcore\**\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <Compile Include="Platforms\net46-netcore\**\*.cs" />
   </ItemGroup>
 
@@ -82,7 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 

--- a/src/Caliburn.Micro.Platform/ConventionManager.cs
+++ b/src/Caliburn.Micro.Platform/ConventionManager.cs
@@ -10,7 +10,7 @@
     using Windows.UI.Xaml.Controls.Primitives;
     using Windows.UI.Xaml.Data;
     using Windows.UI.Xaml.Markup;
-    using EventTrigger = Microsoft.Xaml.Interactions.Core.EventTriggerBehavior;
+    using EventTrigger = Microsoft.Xaml.Interactivity.EventTriggerBehavior;
     using Windows.UI.Xaml.Shapes;
 #elif AVALONIA
     using System.Collections.Specialized;
@@ -472,7 +472,7 @@
             bool hasBinding = element.IsSet(property);
             //TODO: (Avalonia) Need to find a way to detect existing bindings on an AvaloniaProperty
             return hasBinding;
-#elif (NET || CAL_NETCORE) && !WinUI3
+#elif (NET || CAL_NETCORE) && !WinUI3 && !WINDOWS_UWP
             return BindingOperations.GetBindingBase(element, property) != null;
 #else
             return element.GetBindingExpression(property) != null;

--- a/src/Caliburn.Micro.Platform/Parser.cs
+++ b/src/Caliburn.Micro.Platform/Parser.cs
@@ -14,7 +14,7 @@ namespace Caliburn.Micro
     using Windows.UI.Xaml;
     using Microsoft.Xaml.Interactivity;
     using TriggerBase = Microsoft.Xaml.Interactivity.IBehavior;
-    using EventTrigger = Microsoft.Xaml.Interactions.Core.EventTriggerBehavior;
+    using EventTrigger = Microsoft.Xaml.Interactivity.EventTriggerBehavior;
     using TriggerAction = Microsoft.Xaml.Interactivity.IAction;
     using System.Text;
     using System.Text.RegularExpressions;

--- a/src/Caliburn.Micro.Platform/Platforms/Maui/ConventionManager.cs
+++ b/src/Caliburn.Micro.Platform/Platforms/Maui/ConventionManager.cs
@@ -178,6 +178,19 @@
 
                    return true;
                };
+            AddElementConvention<CollectionView>(CollectionView.ItemsSourceProperty, "SelectedItem", "ItemSelected")
+                .ApplyBinding = (viewModelType, path, property, element, convention) =>
+                {
+                    if (!SetBindingWithoutBindingOrValueOverwrite(viewModelType, path, property, element, convention, ItemsView<Cell>.ItemsSourceProperty))
+                    {
+                        return false;
+                    }
+
+                    ConfigureSelectedItem(element, CollectionView.SelectedItemProperty, viewModelType, path);
+                    ApplyItemTemplate((ItemsView<Cell>)element, property);
+
+                    return true;
+                };
             AddElementConvention<Label>(Label.TextProperty, "Text", "Focused");
             AddElementConvention<Image>(Image.SourceProperty, "Source", "Focused");
             AddElementConvention<Entry>(Entry.TextProperty, "Text", "TextChanged");

--- a/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
+++ b/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
@@ -7,8 +7,44 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
-    <LangVersion>10</LangVersion>
+    <LangVersion>10.0</LangVersion>
+    <DefineConstants>WINDOWS_UWP</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Label="Package">
+    <None Include="..\..\CaliburnIcon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="Platforms\uap\Caliburn.Micro.Platform.rd.xml" PackagePath="lib\uap10.0.19041\Caliburn.Micro.Platform\Properties\Caliburn.Micro.Platform.rd.xml" Pack="true" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Caliburn.Micro.Platform\Action.cs" Link="Action.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ActionExecutionContext.cs" Link="ActionExecutionContext.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ActionMessage.cs" Link="ActionMessage.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\Bind.cs" Link="Bind.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\BindingScope.cs" Link="BindingScope.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\BooleanToVisibilityConverter.cs" Link="BooleanToVisibilityConverter.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ChildResolver.cs" Link="ChildResolver.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ConventionManager.cs" Link="ConventionManager.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\DependencyPropertyHelper.cs" Link="DependencyPropertyHelper.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ElementConvention.cs" Link="ElementConvention.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\IHaveParameters.cs" Link="IHaveParameters.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\Message.cs" Link="Message.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\MessageBinder.cs" Link="MessageBinder.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\Parser.cs" Link="Parser.cs" />
+
+    <Compile Include="..\Caliburn.Micro.Platform\View.cs" Link="View.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ViewLocator.cs" Link="ViewLocator.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ViewModelBinder.cs" Link="ViewModelBinder.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\XamlPlatformProvider.cs" Link="XamlPlatformProvider.cs" />
+
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />
+    <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>

--- a/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
+++ b/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
@@ -16,7 +16,6 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Include="Platforms\uap\Caliburn.Micro.Platform.rd.xml" PackagePath="lib\uap10.0.19041\Caliburn.Micro.Platform\Properties\Caliburn.Micro.Platform.rd.xml" Pack="true" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Caliburn.Micro.Platform\Action.cs" Link="Action.cs" />
@@ -39,7 +38,10 @@
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelBinder.cs" Link="ViewModelBinder.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\XamlPlatformProvider.cs" Link="XamlPlatformProvider.cs" />
-    <Compile Include="..\Caliburn.Micro.Platform\Platforms\uap\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="*.cs" />
+    <Compile Include="..\Caliburn.Micro.Platform\Platforms\uap\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1" />
@@ -50,6 +52,7 @@
     <ProjectReference Include="..\Caliburn.Micro.Platform.Core\Caliburn.Micro.Platform.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 </Project>

--- a/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
+++ b/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
@@ -39,7 +39,7 @@
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelBinder.cs" Link="ViewModelBinder.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\XamlPlatformProvider.cs" Link="XamlPlatformProvider.cs" />
-
+    <Compile Include="..\Caliburn.Micro.Platform\Platforms\uap\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1" />

--- a/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
+++ b/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Nullable>enable</Nullable>
+    <UseUwp>true</UseUwp>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <IsAotCompatible>true</IsAotCompatible>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+  </ItemGroup>
+</Project>

--- a/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
+++ b/src/Caliburn.Micro.UWP/Caliburn.Micro.UWP.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
@@ -40,6 +40,10 @@
     <Compile Include="..\Caliburn.Micro.Platform\ViewModelLocator.cs" Link="ViewModelLocator.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\XamlPlatformProvider.cs" Link="XamlPlatformProvider.cs" />
 
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1" />
+    <PackageReference Include="StrongNamer" Version="0.2.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Caliburn.Micro.Core\Caliburn.Micro.Core.csproj" />

--- a/src/Caliburn.Micro.UWP/Class1.cs
+++ b/src/Caliburn.Micro.UWP/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace Caliburn.Micro.UWP
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Caliburn.Micro.UWP/Class1.cs
+++ b/src/Caliburn.Micro.UWP/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Caliburn.Micro.UWP
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
+++ b/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Caliburn.Micro</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -64,14 +64,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
 
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
 </Project>

--- a/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
+++ b/src/Caliburn.Micro.WinUI3/Caliburn.Micro.WinUI3.csproj
@@ -41,7 +41,7 @@
 
     </ItemGroup>
 
-  <ItemGroup >
+  <ItemGroup>
     <Compile Remove="*.cs" />
     <Compile Include="..\Caliburn.Micro.Platform\Platforms\uap\**\*.cs" />
   </ItemGroup>
@@ -64,9 +64,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.220902.1-preview1" />
-      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
 
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
 </Project>

--- a/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   

--- a/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
+++ b/src/Caliburn.Micro.Xamarin.Forms/Caliburn.Micro.Xamarin.Forms.csproj
@@ -88,8 +88,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.91" />
   </ItemGroup>
   
 </Project>

--- a/src/Caliburn.Micro.sln
+++ b/src/Caliburn.Micro.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32421.90
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11925.98 stable
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Caliburn.Micro.Core", "Caliburn.Micro.Core\Caliburn.Micro.Core.csproj", "{F36828EE-446C-42F2-A0EC-D4FB112BD183}"
 EndProject
@@ -24,6 +24,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caliburn.Micro.Maui.Tests", "Caliburn.Micro.Maui.Tests\Caliburn.Micro.Maui.Tests.csproj", "{55521CEA-F8EB-44DD-8D9D-F28F46407F59}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caliburn.Micro.WinUI3", "Caliburn.Micro.WinUI3\Caliburn.Micro.WinUI3.csproj", "{E60034B8-5473-4BB0-91C7-A3E08822334A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caliburn.Micro.UWP", "Caliburn.Micro.UWP\Caliburn.Micro.UWP.csproj", "{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -213,6 +215,22 @@ Global
 		{E60034B8-5473-4BB0-91C7-A3E08822334A}.Release|x64.Build.0 = Release|Any CPU
 		{E60034B8-5473-4BB0-91C7-A3E08822334A}.Release|x86.ActiveCfg = Release|Any CPU
 		{E60034B8-5473-4BB0-91C7-A3E08822334A}.Release|x86.Build.0 = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|ARM.Build.0 = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|x64.Build.0 = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Debug|x86.Build.0 = Debug|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|ARM.Build.0 = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|x64.ActiveCfg = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|x64.Build.0 = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|x86.ActiveCfg = Release|Any CPU
+		{4CE3B536-CCD0-4A14-82B1-3FE7D31884A3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request updates package dependencies, target frameworks, and platform-specific conventions to ensure compatibility with the latest .NET, Avalonia, and MAUI releases. The most important changes are grouped below.

**Dependency and SDK Updates:**

* Upgraded Avalonia, Avalonia.Desktop, Avalonia.Markup.Xaml.Loader, and AvaloniaUI.DiagnosticsSupport packages to version 12.1.0/2.2.3 in both `Caliburn.Micro.Avalonia` and its test project for improved compatibility and bug fixes. [[1]](diffhunk://#diff-e3fbfc36d57f1c4655bfae32dfcc61544655870f5c06f05396572ec0ff96cec5L36-R45) [[2]](diffhunk://#diff-8b9d4759e2ca3a1837a7c4f27e3e240c599e0e0e88d8900edf2a09cab2282f6aL48-R54)
* Updated `Xaml.Behaviors.Avalonia` and `Xaml.Behaviors.Interactivity` to version 12.0.5 in both Avalonia projects. [[1]](diffhunk://#diff-e3fbfc36d57f1c4655bfae32dfcc61544655870f5c06f05396572ec0ff96cec5L36-R45) [[2]](diffhunk://#diff-8b9d4759e2ca3a1837a7c4f27e3e240c599e0e0e88d8900edf2a09cab2282f6aL18-R20)
* Upgraded `Microsoft.Maui.Controls` to 10.0.x in both `Caliburn.Micro.Maui` and its test project, and updated test target frameworks to .NET 10.0 for MAUI. [[1]](diffhunk://#diff-f0ca3f359c04f007369a684fa1ccf6cd4a306d84d09b0dbabfe0632ff45d5762L4-R15) [[2]](diffhunk://#diff-f0ca3f359c04f007369a684fa1ccf6cd4a306d84d09b0dbabfe0632ff45d5762L121-R121) [[3]](diffhunk://#diff-030908f906ef05867136baaaf8b2f92a393f65f82e7e0c7ac3d91dec440af2a9L4-R4) [[4]](diffhunk://#diff-030908f906ef05867136baaaf8b2f92a393f65f82e7e0c7ac3d91dec440af2a9L19-R23)
* Updated `Microsoft.NET.Test.Sdk` to 18.7.0 and `xunit.runner.visualstudio` to 3.1.5 in all test projects, ensuring compatibility with the latest test runner features. [[1]](diffhunk://#diff-8b9d4759e2ca3a1837a7c4f27e3e240c599e0e0e88d8900edf2a09cab2282f6aL18-R20) [[2]](diffhunk://#diff-f649d7443d6762650b6f63beb94c137c5d5e4fa3e65def617d39ed3655adfbecL17-R17) [[3]](diffhunk://#diff-030908f906ef05867136baaaf8b2f92a393f65f82e7e0c7ac3d91dec440af2a9L19-R23) [[4]](diffhunk://#diff-ce90748e59f63442246fae18b1ff88d8678b7565c4bc6cb549fda466051fdf90L17-R20)
* Upgraded `Microsoft.SourceLink.GitHub` to 10.0.300 in all projects for improved source link support. [[1]](diffhunk://#diff-5555b79aaee8a14d94af70b8465705692bc6456437c5097564e346d677ad3376L37-R37) [[2]](diffhunk://#diff-bbb06d4851a3ff15f185c6fd3c6a39c1a87152f5c1b04f658506a4faf04adcd6L17-R17) [[3]](diffhunk://#diff-4830d5140b500c825dbd6742825586f3499939d5a9bd3eab73e60cbdfa5d48c0L85-R85) [[4]](diffhunk://#diff-f0ca3f359c04f007369a684fa1ccf6cd4a306d84d09b0dbabfe0632ff45d5762L132-R148)

**Platform and Target Framework Changes:**

* Updated MAUI library and test projects to target .NET 10.0 and adjusted platform-specific build logic accordingly. [[1]](diffhunk://#diff-f0ca3f359c04f007369a684fa1ccf6cd4a306d84d09b0dbabfe0632ff45d5762L4-R15) [[2]](diffhunk://#diff-f0ca3f359c04f007369a684fa1ccf6cd4a306d84d09b0dbabfe0632ff45d5762L89-R99)
* Removed UWP (`uap10.0.19041`) from `Caliburn.Micro.Platform` target frameworks, reflecting a shift away from UWP support.

**Bug Fixes and Platform Compatibility:**

* Fixed `EventTrigger` type aliasing for Avalonia and MAUI to use the correct namespace, resolving potential runtime issues. [[1]](diffhunk://#diff-119c904e9d8477d486a4ba35e4eb26e716ecf3de6b5171a870622c1f8d9cf8a5L13-R13) [[2]](diffhunk://#diff-4e647466e5ebb8d35d31f2b138420d5dab917575247e4344489fbab07165733cL17-R17)
* Updated binding detection logic in `ConventionManager` to exclude UWP, ensuring correct behavior on supported platforms.
* Added a new element convention for `CollectionView` in MAUI, enabling proper binding and item template application for modern MAUI controls.

**Other Minor Updates:**

* Bumped `Microsoft.Xaml.Behaviors.Wpf` to 1.1.142 in all relevant projects for WPF compatibility. [[1]](diffhunk://#diff-ce90748e59f63442246fae18b1ff88d8678b7565c4bc6cb549fda466051fdf90L17-R20) [[2]](diffhunk://#diff-4830d5140b500c825dbd6742825586f3499939d5a9bd3eab73e60cbdfa5d48c0L41-R41) [[3]](diffhunk://#diff-4830d5140b500c825dbd6742825586f3499939d5a9bd3eab73e60cbdfa5d48c0L50-R54)
* Minor project file encoding fix for `Caliburn.Micro.Platform.Core`.

These updates collectively modernize the codebase, improve cross-platform compatibility, and ensure the project can take advantage of the latest features and fixes in its dependencies.